### PR TITLE
make import scheduler cron expression configurable via env var

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       DB_PASSWORD: ${DB_PASSWORD:-changeme}
       API_BEARER_TOKEN: ${API_BEARER_TOKEN:-changeme}
       IMPORT_FOLDER: /data/import
+      IMPORT_SCHEDULE: ${IMPORT_SCHEDULE:-0 0 12 * * ?}
       DOMAIN: ${DOMAIN:-localhost}
       IMPRINT_NAME: ${IMPRINT_NAME:-}
       IMPRINT_STREET: ${IMPRINT_STREET:-}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -7,4 +7,4 @@ spring:
 
 import:
   folder: ${IMPORT_FOLDER:${user.home}/ranking-import}
-  schedule: "0 */30 * * * ?"
+  schedule: "${IMPORT_SCHEDULE:0 */30 * * * ?}"

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -9,4 +9,4 @@ spring:
       minimum-idle: 2
 
 import:
-  schedule: "0 */5 * * * ?"
+  schedule: "${IMPORT_SCHEDULE:0 */5 * * * ?}"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,7 +23,7 @@ api:
 
 import:
   folder: ${IMPORT_FOLDER:${user.home}/ranking-import}
-  schedule: "0 0 12 * * ?"
+  schedule: "${IMPORT_SCHEDULE:0 0 12 * * ?}"
 
 imprint:
   domain: ${DOMAIN:localhost}


### PR DESCRIPTION
## Summary

- `IMPORT_SCHEDULE` Umgebungsvariable erlaubt das Überschreiben des Cron-Ausdrucks für den Import-Scheduler
- Profile-spezifische Defaults bleiben erhalten (`dev`: alle 30 Min., `local`: alle 5 Min., Default: täglich 12 Uhr)
- `docker-compose.yml` reicht `IMPORT_SCHEDULE` durch (Default: `0 0 12 * * ?`)

## Test plan

- [ ] Anwendung ohne `IMPORT_SCHEDULE` starten — Profil-Default greift wie bisher
- [ ] `IMPORT_SCHEDULE=0 0 6 * * ?` setzen und starten — Scheduler läuft um 6 Uhr statt 12 Uhr
- [ ] Docker-Container via `docker-compose up` starten und Log prüfen, ob Cron-Ausdruck korrekt übernommen wird

🤖 Generated with [Claude Code](https://claude.com/claude-code)