### PR TITLE
Add New Relic Java agent to Docker deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,14 +6,26 @@ RUN ./mvnw dependency:go-offline -q
 COPY src src
 RUN ./mvnw package -DskipTests --no-transfer-progress
 
+ARG NEW_RELIC_AGENT_VERSION=8.21.0
+RUN apt-get update -q && apt-get install -y -q --no-install-recommends unzip curl \
+    && curl -fsSL "https://download.newrelic.com/newrelic/java-agent/newrelic-agent/${NEW_RELIC_AGENT_VERSION}/newrelic-java-${NEW_RELIC_AGENT_VERSION}.zip" \
+       -o newrelic-java.zip \
+    && unzip -q newrelic-java.zip \
+    && rm newrelic-java.zip \
+    && apt-get purge -y --auto-remove curl unzip \
+    && rm -rf /var/lib/apt/lists/*
+
 FROM eclipse-temurin:25-jre-alpine
 WORKDIR /app
 RUN adduser -D -s /bin/false appuser
 COPY --from=builder /app/target/*.jar app.jar
-RUN chown appuser:appuser app.jar
+COPY --from=builder /app/newrelic/newrelic.jar newrelic/newrelic.jar
+COPY newrelic.yml newrelic/newrelic.yml
+RUN chown -R appuser:appuser app.jar newrelic/
 USER appuser
 EXPOSE 8080
 ENTRYPOINT ["java", \
+  "-javaagent:/app/newrelic/newrelic.jar", \
   "-XX:MaxRAMPercentage=75.0", \
   "-XX:+UseZGC", \
   "-XX:+ZGenerational", \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
       IMPRINT_CITY: ${IMPRINT_CITY:-}
       IMPRINT_PHONE: ${IMPRINT_PHONE:-}
       IMPRINT_MAIL: ${IMPRINT_MAIL:-}
+      NEW_RELIC_LICENSE_KEY: ${NEW_RELIC_LICENSE_KEY:-}
+      NEW_RELIC_APP_NAME: ${NEW_RELIC_APP_NAME:-ranking-info}
     volumes:
       - import-data:/data/import
     depends_on:

--- a/newrelic.yml
+++ b/newrelic.yml
@@ -1,0 +1,30 @@
+common: &default_settings
+  # License key is read from NEW_RELIC_LICENSE_KEY environment variable.
+  # App name is read from NEW_RELIC_APP_NAME environment variable.
+  license_key: '<%= ENV["NEW_RELIC_LICENSE_KEY"] %>'
+  app_name: <%= ENV["NEW_RELIC_APP_NAME"] || "ranking-info" %>
+
+  log_level: info
+  # Log to stdout so Docker captures all output in one stream.
+  log_file_name: STDOUT
+
+  distributed_tracing:
+    enabled: true
+
+  application_logging:
+    enabled: true
+    forwarding:
+      enabled: true
+    local_decorating:
+      enabled: false
+
+production:
+  <<: *default_settings
+
+development:
+  <<: *default_settings
+  monitor_mode: false
+
+test:
+  <<: *default_settings
+  monitor_mode: false


### PR DESCRIPTION
## Summary

- Downloads New Relic Java agent v8.21.0 via `curl` during the Docker builder stage (no Maven dependency needed)
- Attaches the agent via `-javaagent:/app/newrelic/newrelic.jar` in the ENTRYPOINT — active only in Docker, not in local dev runs
- Adds `newrelic.yml` with stdout logging and distributed tracing enabled; license key and app name are read from environment variables
- Extends `docker-compose.yml` with `NEW_RELIC_LICENSE_KEY` and `NEW_RELIC_APP_NAME` (both fail-safe: empty default, app still starts without a key)

## Test plan

- [x] `./mvnw test` passes (120 tests, 0 failures)
- [x] `./mvnw spotless:check pmd:check spotbugs:check` passes
- [x] Docker image builds successfully (`docker build .`)
- [x] Container starts without `NEW_RELIC_LICENSE_KEY` set (fail-safe)
- [x] Container starts with a valid `NEW_RELIC_LICENSE_KEY` and app appears in New Relic APM