### PR TITLE
Add New Relic Infrastructure agent with PostgreSQL integration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,31 @@ services:
           cpus: "0.5"
     restart: unless-stopped
 
+  newrelic-infra:
+    image: newrelic/infrastructure-bundle:3.3.13
+    privileged: true
+    pid: host
+    cap_add:
+      - SYS_PTRACE
+    environment:
+      NRIA_LICENSE_KEY: ${NEW_RELIC_LICENSE_KEY:-}
+      NRIA_DISPLAY_NAME: ${NEW_RELIC_HOST_DISPLAY_NAME:-ranking-info-host}
+      NRIA_PASSTHROUGH_ENVIRONMENT: DB_PASSWORD
+      DB_PASSWORD: ${DB_PASSWORD:-changeme}
+    volumes:
+      - /:/host:ro,rslave
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./newrelic/postgresql-config.yml:/etc/newrelic-infra/integrations.d/postgresql-config.yml:ro
+    depends_on:
+      postgres:
+        condition: service_healthy
+    deploy:
+      resources:
+        limits:
+          memory: 150m
+          cpus: "0.25"
+    restart: unless-stopped
+
 volumes:
   postgres-data:
   import-data:

--- a/newrelic/postgresql-config.yml
+++ b/newrelic/postgresql-config.yml
@@ -1,0 +1,15 @@
+integrations:
+  - name: nri-postgresql
+    env:
+      USERNAME: ranking_info
+      PASSWORD: ${DB_PASSWORD}
+      HOSTNAME: postgres
+      PORT: 5432
+      DATABASE: ranking_info
+      COLLECT_DB_LOCK_METRICS: "true"
+      COLLECT_BLOAT_METRICS: "false"
+      ENABLE_SSL: "false"
+    interval: 30s
+    labels:
+      service: ranking-info
+      env: production


### PR DESCRIPTION
## Summary

- Adds `newrelic/infrastructure-bundle:3.3.13` as a sidecar service in `docker-compose.yml`
- **Host monitoring**: CPU, memory, disk, network and Docker container metrics — collected via host namespace access (`pid: host`, `/:/host` mount, `docker.sock`)
- **PostgreSQL monitoring**: `nri-postgresql` integration (bundled in the image) collects query stats, connection counts, buffer hit rates, lock metrics etc. — connects to the `postgres` service by hostname
- `DB_PASSWORD` is forwarded to the integration config via `NRIA_PASSTHROUGH_ENVIRONMENT`; no secrets are stored in committed files
- New environment variable `NEW_RELIC_HOST_DISPLAY_NAME` (default: `ranking-info-host`) controls the display name in New Relic

## Required environment variables

| Variable | Purpose |
|---|---|
| `NEW_RELIC_LICENSE_KEY` | Already used by Java agent |
| `NEW_RELIC_HOST_DISPLAY_NAME` | Optional display name (default: `ranking-info-host`) |

## Test plan

- [ ] `docker compose up` starts all three services without errors
- [ ] Infrastructure agent container logs show no license key errors (when key is set)
- [ ] Host metrics appear in New Relic Infrastructure under the configured display name
- [ ] PostgreSQL metrics appear under *Integrations > PostgreSQL* in New Relic
- [ ] App starts normally without `NEW_RELIC_LICENSE_KEY` (fail-safe)