### PR TITLE
add htmx for partial table updates on search pages

### DIFF
--- a/src/main/java/de/hdawg/rankinginfo/web/ClubController.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/ClubController.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -35,6 +36,7 @@ public class ClubController {
   public String index(
       @RequestParam(required = false) String commit,
       @RequestParam(required = false) String club,
+      @RequestHeader(value = "HX-Request", required = false) String htmxRequest,
       Model model) {
 
     var params = new HashMap<String, Object>();
@@ -71,7 +73,7 @@ public class ClubController {
         model.addAttribute("clubs", clubs);
       }
     }
-    return "clubs/index";
+    return htmxRequest != null ? "clubs/index :: results" : "clubs/index";
   }
 
   @GetMapping("/{id}")

--- a/src/main/java/de/hdawg/rankinginfo/web/ListingController.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/ListingController.java
@@ -6,6 +6,7 @@ import java.util.Locale;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -32,6 +33,7 @@ public class ListingController {
       @RequestParam(required = false) String club,
       @RequestParam(name = "year_end", defaultValue = "0") String yearEnd,
       @RequestParam(required = false) String commit,
+      @RequestHeader(value = "HX-Request", required = false) String htmxRequest,
       Model model) {
 
     model.addAttribute("quarters", rankingService.fetchAvailableQuarters());
@@ -63,7 +65,7 @@ public class ListingController {
       model.addAttribute("rankings", rankings.getContent());
       model.addAttribute("previousPositions", prevPositions);
     }
-    return "listing/index";
+    return htmxRequest != null ? "listing/index :: results" : "listing/index";
   }
 
   private static String toAgeGroupSlug(String gender, String ageGroup) {

--- a/src/main/java/de/hdawg/rankinginfo/web/PlayerController.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/PlayerController.java
@@ -11,6 +11,7 @@ import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 import jakarta.servlet.http.HttpServletResponse;
+
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/de/hdawg/rankinginfo/web/PlayerController.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/PlayerController.java
@@ -10,10 +10,12 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
@@ -52,8 +54,10 @@ public class PlayerController {
       @RequestParam(required = false) String yob,
       @RequestParam(name = "dtb_id", required = false) String dtbId,
       @RequestParam(required = false) String commit,
+      @RequestHeader(value = "HX-Request", required = false) String htmxRequest,
       Model model,
-      RedirectAttributes redirect) {
+      RedirectAttributes redirect,
+      HttpServletResponse response) {
 
     if (dtbId != null && !dtbId.isBlank()) {
       long idNum;
@@ -66,21 +70,21 @@ public class PlayerController {
       int start = (int) (idNum * Math.pow(10.0, missing));
       int end = start + (int) Math.pow(10.0, missing) - 1;
       var players = playerService.findPlayersByDtbIdRange(start, end);
-      if (players.size() == 1) return REDIRECT_PLAYER + players.get(0).dtbId();
+      if (players.size() == 1) return redirectToPlayer(players.get(0).dtbId(), htmxRequest, response);
       model.addAttribute(MODEL_PLAYERS, players);
     } else if (lastname != null && !lastname.isBlank() && yob != null && !yob.isBlank()) {
       int yobMale = Integer.parseInt(yob.trim().substring(2, 4)) + 100;
       var players = playerService.findPlayersByLastnameAndYob(lastname.trim(), yobMale, yobMale + 100);
-      if (players.size() == 1) return REDIRECT_PLAYER + players.get(0).dtbId();
+      if (players.size() == 1) return redirectToPlayer(players.get(0).dtbId(), htmxRequest, response);
       model.addAttribute(MODEL_PLAYERS, players);
     } else if (lastname != null && !lastname.isBlank()) {
       var players = playerService.findPlayersByLastname(lastname.trim());
-      if (players.size() == 1) return REDIRECT_PLAYER + players.get(0).dtbId();
+      if (players.size() == 1) return redirectToPlayer(players.get(0).dtbId(), htmxRequest, response);
       model.addAttribute(MODEL_PLAYERS, players);
     } else if (yob != null && !yob.isBlank()) {
       int yobMale = Integer.parseInt(yob.trim().substring(2, 4)) + 100;
       var players = playerService.findPlayersByYob(yobMale, yobMale + 100);
-      if (players.size() == 1) return REDIRECT_PLAYER + players.get(0).dtbId();
+      if (players.size() == 1) return redirectToPlayer(players.get(0).dtbId(), htmxRequest, response);
       model.addAttribute(MODEL_PLAYERS, players);
     }
 
@@ -89,7 +93,15 @@ public class PlayerController {
     params.put("yob", yob);
     params.put("dtb_id", dtbId);
     model.addAttribute("params", params);
-    return "players/index";
+    return htmxRequest != null ? "players/index :: results" : "players/index";
+  }
+
+  private String redirectToPlayer(int dtbId, String htmxRequest, HttpServletResponse response) {
+    if (htmxRequest != null) {
+      response.setHeader("HX-Redirect", "/players/" + dtbId);
+      return "players/index :: results";
+    }
+    return REDIRECT_PLAYER + dtbId;
   }
 
   @GetMapping("/{id}")

--- a/src/main/resources/static/css/application.css
+++ b/src/main/resources/static/css/application.css
@@ -1,2 +1,785 @@
 /*! tailwindcss v4.3.0 | MIT License | https://tailwindcss.com */
-@layer properties{@supports (((-webkit-hyphens:none)) and (not (margin-trim:inline))) or ((-moz-orient:inline) and (not (color:rgb(from red r g b)))){*,:before,:after,::backdrop{--tw-border-style:solid;--tw-font-weight:initial;--tw-tracking:initial;--tw-shadow:0 0 #0000;--tw-shadow-color:initial;--tw-shadow-alpha:100%;--tw-inset-shadow:0 0 #0000;--tw-inset-shadow-color:initial;--tw-inset-shadow-alpha:100%;--tw-ring-color:initial;--tw-ring-shadow:0 0 #0000;--tw-inset-ring-color:initial;--tw-inset-ring-shadow:0 0 #0000;--tw-ring-inset:initial;--tw-ring-offset-width:0px;--tw-ring-offset-color:#fff;--tw-ring-offset-shadow:0 0 #0000}}}@layer theme{:root,:host{--font-sans:ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";--font-mono:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;--color-red-100:oklch(93.6% .032 17.717);--color-red-400:oklch(70.4% .191 22.216);--color-red-800:oklch(44.4% .177 26.899);--color-green-500:oklch(72.3% .219 149.579);--color-blue-50:oklch(97% .014 254.604);--color-blue-400:oklch(70.7% .165 254.624);--color-blue-800:oklch(42.4% .199 265.638);--color-gray-50:oklch(98.5% .002 247.839);--color-gray-100:oklch(96.7% .003 264.542);--color-gray-200:oklch(92.8% .006 264.531);--color-gray-300:oklch(87.2% .01 258.338);--color-gray-500:oklch(55.1% .027 264.364);--color-gray-600:oklch(44.6% .03 256.802);--color-gray-800:oklch(27.8% .033 256.848);--color-gray-900:oklch(21% .034 264.665);--color-white:#fff;--spacing:.25rem;--text-xs:.75rem;--text-xs--line-height:calc(1 / .75);--text-sm:.875rem;--text-sm--line-height:calc(1.25 / .875);--text-base:1rem;--text-base--line-height:calc(1.5 / 1);--text-lg:1.125rem;--text-lg--line-height:calc(1.75 / 1.125);--text-xl:1.25rem;--text-xl--line-height:calc(1.75 / 1.25);--text-2xl:1.5rem;--text-2xl--line-height:calc(2 / 1.5);--text-3xl:1.875rem;--text-3xl--line-height:calc(2.25 / 1.875);--font-weight-semibold:600;--font-weight-bold:700;--tracking-normal:0em;--default-font-family:var(--font-sans);--default-mono-font-family:var(--font-mono);--color-brand:#3e8ed0}}@layer base{*,:after,:before,::backdrop{box-sizing:border-box;border:0 solid;margin:0;padding:0}::file-selector-button{box-sizing:border-box;border:0 solid;margin:0;padding:0}html,:host{-webkit-text-size-adjust:100%;tab-size:4;line-height:1.5;font-family:var(--default-font-family,ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji");font-feature-settings:var(--default-font-feature-settings,normal);font-variation-settings:var(--default-font-variation-settings,normal);-webkit-tap-highlight-color:transparent}hr{height:0;color:inherit;border-top-width:1px}abbr:where([title]){-webkit-text-decoration:underline dotted;text-decoration:underline dotted}h1,h2,h3,h4,h5,h6{font-size:inherit;font-weight:inherit}a{color:inherit;-webkit-text-decoration:inherit;-webkit-text-decoration:inherit;-webkit-text-decoration:inherit;text-decoration:inherit}b,strong{font-weight:bolder}code,kbd,samp,pre{font-family:var(--default-mono-font-family,ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace);font-feature-settings:var(--default-mono-font-feature-settings,normal);font-variation-settings:var(--default-mono-font-variation-settings,normal);font-size:1em}small{font-size:80%}sub,sup{vertical-align:baseline;font-size:75%;line-height:0;position:relative}sub{bottom:-.25em}sup{top:-.5em}table{text-indent:0;border-color:inherit;border-collapse:collapse}:-moz-focusring{outline:auto}progress{vertical-align:baseline}summary{display:list-item}ol,ul,menu{list-style:none}img,svg,video,canvas,audio,iframe,embed,object{vertical-align:middle;display:block}img,video{max-width:100%;height:auto}button,input,select,optgroup,textarea{font:inherit;font-feature-settings:inherit;font-variation-settings:inherit;letter-spacing:inherit;color:inherit;opacity:1;background-color:#0000;border-radius:0}::file-selector-button{font:inherit;font-feature-settings:inherit;font-variation-settings:inherit;letter-spacing:inherit;color:inherit;opacity:1;background-color:#0000;border-radius:0}:where(select:is([multiple],[size])) optgroup{font-weight:bolder}:where(select:is([multiple],[size])) optgroup option{padding-inline-start:20px}::file-selector-button{margin-inline-end:4px}::placeholder{opacity:1}@supports (not ((-webkit-appearance:-apple-pay-button))) or (contain-intrinsic-size:1px){::placeholder{color:currentColor}@supports (color:color-mix(in lab, red, red)){::placeholder{color:color-mix(in oklab, currentcolor 50%, transparent)}}}::-webkit-search-decoration{-webkit-appearance:none}::-webkit-date-and-time-value{min-height:1lh;text-align:inherit}::-webkit-datetime-edit{display:inline-flex}::-webkit-datetime-edit-fields-wrapper{padding:0}::-webkit-datetime-edit{padding-block:0}::-webkit-datetime-edit-year-field{padding-block:0}::-webkit-datetime-edit-month-field{padding-block:0}::-webkit-datetime-edit-day-field{padding-block:0}::-webkit-datetime-edit-hour-field{padding-block:0}::-webkit-datetime-edit-minute-field{padding-block:0}::-webkit-datetime-edit-second-field{padding-block:0}::-webkit-datetime-edit-millisecond-field{padding-block:0}::-webkit-datetime-edit-meridiem-field{padding-block:0}::-webkit-calendar-picker-indicator{line-height:1}:-moz-ui-invalid{box-shadow:none}button,input:where([type=button],[type=reset],[type=submit]){appearance:button}::file-selector-button{appearance:button}::-webkit-inner-spin-button{height:auto}::-webkit-outer-spin-button{height:auto}[hidden]:where(:not([hidden=until-found])){display:none!important}h1,h2,h3,h4,h5,h6{line-height:1}h1{letter-spacing:-2px;text-align:center;margin-bottom:30px;font-size:3em}h2{letter-spacing:-1px;text-align:center;color:#999;margin-bottom:30px;font-size:1.2em;font-weight:400}p{font-size:1.1em;line-height:1.7em}td,th{padding:.5em .75em}section{overflow:auto}textarea{resize:vertical}}@layer components{.striped{background-color:#efefef}.table th.center,.table td.center{text-align:center}.ri-icon{vertical-align:-.125em;width:1em;height:1em;display:inline-block}.ri-icon-green{color:green;font-size:1em}.ri-icon-red{color:red;font-size:1em}.ri-icon-yellow{color:#d4a017;font-size:1em}.debug_dump{clear:both;float:left;background-color:#ddd7d7;border-radius:6px;width:100%;margin-top:45px;padding:10px}}@layer utilities{.invisible{visibility:hidden}.sr-only{clip-path:inset(50%);white-space:nowrap;border-width:0;width:1px;height:1px;margin:-1px;padding:0;position:absolute;overflow:hidden}.col-span-1{grid-column:span 1/span 1}.col-span-2{grid-column:span 2/span 2}.col-span-4{grid-column:span 4/span 4}.mx-auto{margin-inline:auto}.mt-1{margin-top:calc(var(--spacing) * 1)}.mt-2{margin-top:calc(var(--spacing) * 2)}.mt-3{margin-top:calc(var(--spacing) * 3)}.mt-4{margin-top:calc(var(--spacing) * 4)}.mb-1{margin-bottom:calc(var(--spacing) * 1)}.mb-2{margin-bottom:calc(var(--spacing) * 2)}.mb-3{margin-bottom:calc(var(--spacing) * 3)}.mb-4{margin-bottom:calc(var(--spacing) * 4)}.mb-5{margin-bottom:calc(var(--spacing) * 5)}.mb-6{margin-bottom:calc(var(--spacing) * 6)}.block{display:block}.flex{display:flex}.grid{display:grid}.hidden{display:none}.inline-flex{display:inline-flex}.table{display:table}.h-0\.5{height:calc(var(--spacing) * .5)}.max-h-7{max-height:calc(var(--spacing) * 7)}.w-5{width:calc(var(--spacing) * 5)}.w-full{width:100%}.max-w-none{max-width:none}.min-w-max{min-width:max-content}.flex-1{flex:1}.cursor-pointer{cursor:pointer}.grid-cols-1{grid-template-columns:repeat(1,minmax(0,1fr))}.grid-cols-2{grid-template-columns:repeat(2,minmax(0,1fr))}.grid-cols-3{grid-template-columns:repeat(3,minmax(0,1fr))}.grid-cols-12{grid-template-columns:repeat(12,minmax(0,1fr))}.flex-wrap{flex-wrap:wrap}.items-center{align-items:center}.items-start{align-items:flex-start}.justify-between{justify-content:space-between}.gap-1{gap:calc(var(--spacing) * 1)}.gap-2{gap:calc(var(--spacing) * 2)}.gap-3{gap:calc(var(--spacing) * 3)}.gap-4{gap:calc(var(--spacing) * 4)}.overflow-hidden{overflow:hidden}.overflow-x-auto{overflow-x:auto}.rounded{border-radius:.25rem}.rounded-t{border-top-left-radius:.25rem;border-top-right-radius:.25rem}.rounded-b{border-bottom-right-radius:.25rem;border-bottom-left-radius:.25rem}.border{border-style:var(--tw-border-style);border-width:1px}.border-t{border-top-style:var(--tw-border-style);border-top-width:1px}.border-b{border-bottom-style:var(--tw-border-style);border-bottom-width:1px}.border-l{border-left-style:var(--tw-border-style);border-left-width:1px}.border-l-4{border-left-style:var(--tw-border-style);border-left-width:4px}.border-blue-400{border-color:var(--color-blue-400)}.border-gray-200{border-color:var(--color-gray-200)}.border-gray-300{border-color:var(--color-gray-300)}.border-gray-600{border-color:var(--color-gray-600)}.border-red-400{border-color:var(--color-red-400)}.bg-blue-50{background-color:var(--color-blue-50)}.bg-brand{background-color:var(--color-brand)}.bg-gray-50{background-color:var(--color-gray-50)}.bg-gray-100{background-color:var(--color-gray-100)}.bg-gray-800{background-color:var(--color-gray-800)}.bg-green-500{background-color:var(--color-green-500)}.bg-red-100{background-color:var(--color-red-100)}.bg-white{background-color:var(--color-white)}.bg-white\/20{background-color:#fff3}@supports (color:color-mix(in lab, red, red)){.bg-white\/20{background-color:color-mix(in oklab, var(--color-white) 20%, transparent)}}.p-2{padding:calc(var(--spacing) * 2)}.p-4{padding:calc(var(--spacing) * 4)}.px-1{padding-inline:calc(var(--spacing) * 1)}.px-2{padding-inline:calc(var(--spacing) * 2)}.px-3{padding-inline:calc(var(--spacing) * 3)}.px-4{padding-inline:calc(var(--spacing) * 4)}.py-1{padding-block:calc(var(--spacing) * 1)}.py-2{padding-block:calc(var(--spacing) * 2)}.py-3{padding-block:calc(var(--spacing) * 3)}.py-12{padding-block:calc(var(--spacing) * 12)}.pb-2{padding-bottom:calc(var(--spacing) * 2)}.text-center{text-align:center}.text-left{text-align:left}.text-right{text-align:right}.text-2xl{font-size:var(--text-2xl);line-height:var(--tw-leading,var(--text-2xl--line-height))}.text-3xl{font-size:var(--text-3xl);line-height:var(--tw-leading,var(--text-3xl--line-height))}.text-base{font-size:var(--text-base);line-height:var(--tw-leading,var(--text-base--line-height))}.text-lg{font-size:var(--text-lg);line-height:var(--tw-leading,var(--text-lg--line-height))}.text-sm{font-size:var(--text-sm);line-height:var(--tw-leading,var(--text-sm--line-height))}.text-xl{font-size:var(--text-xl);line-height:var(--tw-leading,var(--text-xl--line-height))}.text-xs{font-size:var(--text-xs);line-height:var(--tw-leading,var(--text-xs--line-height))}.font-bold{--tw-font-weight:var(--font-weight-bold);font-weight:var(--font-weight-bold)}.font-semibold{--tw-font-weight:var(--font-weight-semibold);font-weight:var(--font-weight-semibold)}.tracking-normal{--tw-tracking:var(--tracking-normal);letter-spacing:var(--tracking-normal)}.text-blue-800{color:var(--color-blue-800)}.text-brand{color:var(--color-brand)}.text-gray-500{color:var(--color-gray-500)}.text-gray-600{color:var(--color-gray-600)}.text-gray-800{color:var(--color-gray-800)}.text-gray-900{color:var(--color-gray-900)}.text-red-800{color:var(--color-red-800)}.text-white{color:var(--color-white)}.italic{font-style:italic}.opacity-90{opacity:.9}.shadow{--tw-shadow:0 1px 3px 0 var(--tw-shadow-color,#0000001a), 0 1px 2px -1px var(--tw-shadow-color,#0000001a);box-shadow:var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow)}.even\:bg-gray-50:nth-child(2n){background-color:var(--color-gray-50)}@media (hover:hover){.hover\:bg-gray-50:hover{background-color:var(--color-gray-50)}.hover\:bg-white\/20:hover{background-color:#fff3}@supports (color:color-mix(in lab, red, red)){.hover\:bg-white\/20:hover{background-color:color-mix(in oklab, var(--color-white) 20%, transparent)}}.hover\:opacity-90:hover{opacity:.9}}@media (min-width:48rem){.md\:flex{display:flex}.md\:hidden{display:none}.md\:inline-block{display:inline-block}.md\:table-cell{display:table-cell}.md\:w-auto{width:auto}.md\:grid-cols-2{grid-template-columns:repeat(2,minmax(0,1fr))}.md\:items-center{align-items:center}.md\:gap-1{gap:calc(var(--spacing) * 1)}.md\:pb-0{padding-bottom:calc(var(--spacing) * 0)}}}@property --tw-border-style{syntax:"*";inherits:false;initial-value:solid}@property --tw-font-weight{syntax:"*";inherits:false}@property --tw-tracking{syntax:"*";inherits:false}@property --tw-shadow{syntax:"*";inherits:false;initial-value:0 0 #0000}@property --tw-shadow-color{syntax:"*";inherits:false}@property --tw-shadow-alpha{syntax:"<percentage>";inherits:false;initial-value:100%}@property --tw-inset-shadow{syntax:"*";inherits:false;initial-value:0 0 #0000}@property --tw-inset-shadow-color{syntax:"*";inherits:false}@property --tw-inset-shadow-alpha{syntax:"<percentage>";inherits:false;initial-value:100%}@property --tw-ring-color{syntax:"*";inherits:false}@property --tw-ring-shadow{syntax:"*";inherits:false;initial-value:0 0 #0000}@property --tw-inset-ring-color{syntax:"*";inherits:false}@property --tw-inset-ring-shadow{syntax:"*";inherits:false;initial-value:0 0 #0000}@property --tw-ring-inset{syntax:"*";inherits:false}@property --tw-ring-offset-width{syntax:"<length>";inherits:false;initial-value:0}@property --tw-ring-offset-color{syntax:"*";inherits:false;initial-value:#fff}@property --tw-ring-offset-shadow{syntax:"*";inherits:false;initial-value:0 0 #0000}
+@layer properties;
+@layer theme, base, components, utilities;
+@layer theme {
+  :root, :host {
+    --font-sans: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji",
+      "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+    --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+      "Courier New", monospace;
+    --color-red-100: oklch(93.6% 0.032 17.717);
+    --color-red-400: oklch(70.4% 0.191 22.216);
+    --color-red-800: oklch(44.4% 0.177 26.899);
+    --color-green-500: oklch(72.3% 0.219 149.579);
+    --color-blue-50: oklch(97% 0.014 254.604);
+    --color-blue-400: oklch(70.7% 0.165 254.624);
+    --color-blue-800: oklch(42.4% 0.199 265.638);
+    --color-gray-50: oklch(98.5% 0.002 247.839);
+    --color-gray-100: oklch(96.7% 0.003 264.542);
+    --color-gray-200: oklch(92.8% 0.006 264.531);
+    --color-gray-300: oklch(87.2% 0.01 258.338);
+    --color-gray-500: oklch(55.1% 0.027 264.364);
+    --color-gray-600: oklch(44.6% 0.03 256.802);
+    --color-gray-800: oklch(27.8% 0.033 256.848);
+    --color-gray-900: oklch(21% 0.034 264.665);
+    --color-white: #fff;
+    --spacing: 0.25rem;
+    --text-xs: 0.75rem;
+    --text-xs--line-height: calc(1 / 0.75);
+    --text-sm: 0.875rem;
+    --text-sm--line-height: calc(1.25 / 0.875);
+    --text-base: 1rem;
+    --text-base--line-height: calc(1.5 / 1);
+    --text-lg: 1.125rem;
+    --text-lg--line-height: calc(1.75 / 1.125);
+    --text-xl: 1.25rem;
+    --text-xl--line-height: calc(1.75 / 1.25);
+    --text-2xl: 1.5rem;
+    --text-2xl--line-height: calc(2 / 1.5);
+    --text-3xl: 1.875rem;
+    --text-3xl--line-height: calc(2.25 / 1.875);
+    --font-weight-semibold: 600;
+    --font-weight-bold: 700;
+    --tracking-normal: 0em;
+    --default-font-family: var(--font-sans);
+    --default-mono-font-family: var(--font-mono);
+    --color-brand: #3e8ed0;
+  }
+}
+@layer base {
+  *, ::after, ::before, ::backdrop, ::file-selector-button {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+    border: 0 solid;
+  }
+  html, :host {
+    line-height: 1.5;
+    -webkit-text-size-adjust: 100%;
+    tab-size: 4;
+    font-family: var(--default-font-family, ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji");
+    font-feature-settings: var(--default-font-feature-settings, normal);
+    font-variation-settings: var(--default-font-variation-settings, normal);
+    -webkit-tap-highlight-color: transparent;
+  }
+  hr {
+    height: 0;
+    color: inherit;
+    border-top-width: 1px;
+  }
+  abbr:where([title]) {
+    -webkit-text-decoration: underline dotted;
+    text-decoration: underline dotted;
+  }
+  h1, h2, h3, h4, h5, h6 {
+    font-size: inherit;
+    font-weight: inherit;
+  }
+  a {
+    color: inherit;
+    -webkit-text-decoration: inherit;
+    text-decoration: inherit;
+  }
+  b, strong {
+    font-weight: bolder;
+  }
+  code, kbd, samp, pre {
+    font-family: var(--default-mono-font-family, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace);
+    font-feature-settings: var(--default-mono-font-feature-settings, normal);
+    font-variation-settings: var(--default-mono-font-variation-settings, normal);
+    font-size: 1em;
+  }
+  small {
+    font-size: 80%;
+  }
+  sub, sup {
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
+  }
+  sub {
+    bottom: -0.25em;
+  }
+  sup {
+    top: -0.5em;
+  }
+  table {
+    text-indent: 0;
+    border-color: inherit;
+    border-collapse: collapse;
+  }
+  :-moz-focusring {
+    outline: auto;
+  }
+  progress {
+    vertical-align: baseline;
+  }
+  summary {
+    display: list-item;
+  }
+  ol, ul, menu {
+    list-style: none;
+  }
+  img, svg, video, canvas, audio, iframe, embed, object {
+    display: block;
+    vertical-align: middle;
+  }
+  img, video {
+    max-width: 100%;
+    height: auto;
+  }
+  button, input, select, optgroup, textarea, ::file-selector-button {
+    font: inherit;
+    font-feature-settings: inherit;
+    font-variation-settings: inherit;
+    letter-spacing: inherit;
+    color: inherit;
+    border-radius: 0;
+    background-color: transparent;
+    opacity: 1;
+  }
+  :where(select:is([multiple], [size])) optgroup {
+    font-weight: bolder;
+  }
+  :where(select:is([multiple], [size])) optgroup option {
+    padding-inline-start: 20px;
+  }
+  ::file-selector-button {
+    margin-inline-end: 4px;
+  }
+  ::placeholder {
+    opacity: 1;
+  }
+  @supports (not (-webkit-appearance: -apple-pay-button))  or (contain-intrinsic-size: 1px) {
+    ::placeholder {
+      color: currentcolor;
+      @supports (color: color-mix(in lab, red, red)) {
+        color: color-mix(in oklab, currentcolor 50%, transparent);
+      }
+    }
+  }
+  textarea {
+    resize: vertical;
+  }
+  ::-webkit-search-decoration {
+    -webkit-appearance: none;
+  }
+  ::-webkit-date-and-time-value {
+    min-height: 1lh;
+    text-align: inherit;
+  }
+  ::-webkit-datetime-edit {
+    display: inline-flex;
+  }
+  ::-webkit-datetime-edit-fields-wrapper {
+    padding: 0;
+  }
+  ::-webkit-datetime-edit, ::-webkit-datetime-edit-year-field, ::-webkit-datetime-edit-month-field, ::-webkit-datetime-edit-day-field, ::-webkit-datetime-edit-hour-field, ::-webkit-datetime-edit-minute-field, ::-webkit-datetime-edit-second-field, ::-webkit-datetime-edit-millisecond-field, ::-webkit-datetime-edit-meridiem-field {
+    padding-block: 0;
+  }
+  ::-webkit-calendar-picker-indicator {
+    line-height: 1;
+  }
+  :-moz-ui-invalid {
+    box-shadow: none;
+  }
+  button, input:where([type="button"], [type="reset"], [type="submit"]), ::file-selector-button {
+    appearance: button;
+  }
+  ::-webkit-inner-spin-button, ::-webkit-outer-spin-button {
+    height: auto;
+  }
+  [hidden]:where(:not([hidden="until-found"])) {
+    display: none !important;
+  }
+}
+@layer utilities {
+  .invisible {
+    visibility: hidden;
+  }
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border-width: 0;
+  }
+  .col-span-1 {
+    grid-column: span 1 / span 1;
+  }
+  .col-span-2 {
+    grid-column: span 2 / span 2;
+  }
+  .col-span-4 {
+    grid-column: span 4 / span 4;
+  }
+  .mx-auto {
+    margin-inline: auto;
+  }
+  .mt-1 {
+    margin-top: calc(var(--spacing) * 1);
+  }
+  .mt-2 {
+    margin-top: calc(var(--spacing) * 2);
+  }
+  .mt-3 {
+    margin-top: calc(var(--spacing) * 3);
+  }
+  .mt-4 {
+    margin-top: calc(var(--spacing) * 4);
+  }
+  .mb-1 {
+    margin-bottom: calc(var(--spacing) * 1);
+  }
+  .mb-2 {
+    margin-bottom: calc(var(--spacing) * 2);
+  }
+  .mb-3 {
+    margin-bottom: calc(var(--spacing) * 3);
+  }
+  .mb-4 {
+    margin-bottom: calc(var(--spacing) * 4);
+  }
+  .mb-5 {
+    margin-bottom: calc(var(--spacing) * 5);
+  }
+  .mb-6 {
+    margin-bottom: calc(var(--spacing) * 6);
+  }
+  .block {
+    display: block;
+  }
+  .flex {
+    display: flex;
+  }
+  .grid {
+    display: grid;
+  }
+  .hidden {
+    display: none;
+  }
+  .inline-flex {
+    display: inline-flex;
+  }
+  .table {
+    display: table;
+  }
+  .h-0\.5 {
+    height: calc(var(--spacing) * 0.5);
+  }
+  .max-h-7 {
+    max-height: calc(var(--spacing) * 7);
+  }
+  .w-5 {
+    width: calc(var(--spacing) * 5);
+  }
+  .w-full {
+    width: 100%;
+  }
+  .max-w-none {
+    max-width: none;
+  }
+  .min-w-max {
+    min-width: max-content;
+  }
+  .flex-1 {
+    flex: 1;
+  }
+  .cursor-pointer {
+    cursor: pointer;
+  }
+  .list-inside {
+    list-style-position: inside;
+  }
+  .list-disc {
+    list-style-type: disc;
+  }
+  .grid-cols-1 {
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+  }
+  .grid-cols-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .grid-cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+  .grid-cols-12 {
+    grid-template-columns: repeat(12, minmax(0, 1fr));
+  }
+  .flex-wrap {
+    flex-wrap: wrap;
+  }
+  .items-center {
+    align-items: center;
+  }
+  .items-start {
+    align-items: flex-start;
+  }
+  .justify-between {
+    justify-content: space-between;
+  }
+  .gap-1 {
+    gap: calc(var(--spacing) * 1);
+  }
+  .gap-2 {
+    gap: calc(var(--spacing) * 2);
+  }
+  .gap-3 {
+    gap: calc(var(--spacing) * 3);
+  }
+  .gap-4 {
+    gap: calc(var(--spacing) * 4);
+  }
+  .overflow-hidden {
+    overflow: hidden;
+  }
+  .overflow-x-auto {
+    overflow-x: auto;
+  }
+  .rounded {
+    border-radius: 0.25rem;
+  }
+  .rounded-t {
+    border-top-left-radius: 0.25rem;
+    border-top-right-radius: 0.25rem;
+  }
+  .rounded-b {
+    border-bottom-right-radius: 0.25rem;
+    border-bottom-left-radius: 0.25rem;
+  }
+  .border {
+    border-style: var(--tw-border-style);
+    border-width: 1px;
+  }
+  .border-t {
+    border-top-style: var(--tw-border-style);
+    border-top-width: 1px;
+  }
+  .border-b {
+    border-bottom-style: var(--tw-border-style);
+    border-bottom-width: 1px;
+  }
+  .border-l {
+    border-left-style: var(--tw-border-style);
+    border-left-width: 1px;
+  }
+  .border-l-4 {
+    border-left-style: var(--tw-border-style);
+    border-left-width: 4px;
+  }
+  .border-blue-400 {
+    border-color: var(--color-blue-400);
+  }
+  .border-gray-200 {
+    border-color: var(--color-gray-200);
+  }
+  .border-gray-300 {
+    border-color: var(--color-gray-300);
+  }
+  .border-gray-600 {
+    border-color: var(--color-gray-600);
+  }
+  .border-red-400 {
+    border-color: var(--color-red-400);
+  }
+  .bg-blue-50 {
+    background-color: var(--color-blue-50);
+  }
+  .bg-brand {
+    background-color: var(--color-brand);
+  }
+  .bg-gray-50 {
+    background-color: var(--color-gray-50);
+  }
+  .bg-gray-100 {
+    background-color: var(--color-gray-100);
+  }
+  .bg-gray-800 {
+    background-color: var(--color-gray-800);
+  }
+  .bg-green-500 {
+    background-color: var(--color-green-500);
+  }
+  .bg-red-100 {
+    background-color: var(--color-red-100);
+  }
+  .bg-white {
+    background-color: var(--color-white);
+  }
+  .bg-white\/20 {
+    background-color: color-mix(in srgb, #fff 20%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-white) 20%, transparent);
+    }
+  }
+  .p-2 {
+    padding: calc(var(--spacing) * 2);
+  }
+  .p-4 {
+    padding: calc(var(--spacing) * 4);
+  }
+  .px-1 {
+    padding-inline: calc(var(--spacing) * 1);
+  }
+  .px-2 {
+    padding-inline: calc(var(--spacing) * 2);
+  }
+  .px-3 {
+    padding-inline: calc(var(--spacing) * 3);
+  }
+  .px-4 {
+    padding-inline: calc(var(--spacing) * 4);
+  }
+  .py-1 {
+    padding-block: calc(var(--spacing) * 1);
+  }
+  .py-2 {
+    padding-block: calc(var(--spacing) * 2);
+  }
+  .py-3 {
+    padding-block: calc(var(--spacing) * 3);
+  }
+  .py-12 {
+    padding-block: calc(var(--spacing) * 12);
+  }
+  .pb-2 {
+    padding-bottom: calc(var(--spacing) * 2);
+  }
+  .text-center {
+    text-align: center;
+  }
+  .text-left {
+    text-align: left;
+  }
+  .text-right {
+    text-align: right;
+  }
+  .text-2xl {
+    font-size: var(--text-2xl);
+    line-height: var(--tw-leading, var(--text-2xl--line-height));
+  }
+  .text-3xl {
+    font-size: var(--text-3xl);
+    line-height: var(--tw-leading, var(--text-3xl--line-height));
+  }
+  .text-base {
+    font-size: var(--text-base);
+    line-height: var(--tw-leading, var(--text-base--line-height));
+  }
+  .text-lg {
+    font-size: var(--text-lg);
+    line-height: var(--tw-leading, var(--text-lg--line-height));
+  }
+  .text-sm {
+    font-size: var(--text-sm);
+    line-height: var(--tw-leading, var(--text-sm--line-height));
+  }
+  .text-xl {
+    font-size: var(--text-xl);
+    line-height: var(--tw-leading, var(--text-xl--line-height));
+  }
+  .text-xs {
+    font-size: var(--text-xs);
+    line-height: var(--tw-leading, var(--text-xs--line-height));
+  }
+  .font-bold {
+    --tw-font-weight: var(--font-weight-bold);
+    font-weight: var(--font-weight-bold);
+  }
+  .font-semibold {
+    --tw-font-weight: var(--font-weight-semibold);
+    font-weight: var(--font-weight-semibold);
+  }
+  .tracking-normal {
+    --tw-tracking: var(--tracking-normal);
+    letter-spacing: var(--tracking-normal);
+  }
+  .text-blue-800 {
+    color: var(--color-blue-800);
+  }
+  .text-brand {
+    color: var(--color-brand);
+  }
+  .text-gray-500 {
+    color: var(--color-gray-500);
+  }
+  .text-gray-600 {
+    color: var(--color-gray-600);
+  }
+  .text-gray-800 {
+    color: var(--color-gray-800);
+  }
+  .text-gray-900 {
+    color: var(--color-gray-900);
+  }
+  .text-red-800 {
+    color: var(--color-red-800);
+  }
+  .text-white {
+    color: var(--color-white);
+  }
+  .italic {
+    font-style: italic;
+  }
+  .opacity-90 {
+    opacity: 90%;
+  }
+  .shadow {
+    --tw-shadow: 0 1px 3px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 1px 2px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .even\:bg-gray-50 {
+    &:nth-child(even) {
+      background-color: var(--color-gray-50);
+    }
+  }
+  .hover\:bg-gray-50 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-gray-50);
+      }
+    }
+  }
+  .hover\:bg-white\/20 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: color-mix(in srgb, #fff 20%, transparent);
+        @supports (color: color-mix(in lab, red, red)) {
+          background-color: color-mix(in oklab, var(--color-white) 20%, transparent);
+        }
+      }
+    }
+  }
+  .hover\:opacity-90 {
+    &:hover {
+      @media (hover: hover) {
+        opacity: 90%;
+      }
+    }
+  }
+  .md\:flex {
+    @media (width >= 48rem) {
+      display: flex;
+    }
+  }
+  .md\:hidden {
+    @media (width >= 48rem) {
+      display: none;
+    }
+  }
+  .md\:inline-block {
+    @media (width >= 48rem) {
+      display: inline-block;
+    }
+  }
+  .md\:table-cell {
+    @media (width >= 48rem) {
+      display: table-cell;
+    }
+  }
+  .md\:w-auto {
+    @media (width >= 48rem) {
+      width: auto;
+    }
+  }
+  .md\:grid-cols-2 {
+    @media (width >= 48rem) {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+  .md\:items-center {
+    @media (width >= 48rem) {
+      align-items: center;
+    }
+  }
+  .md\:gap-1 {
+    @media (width >= 48rem) {
+      gap: calc(var(--spacing) * 1);
+    }
+  }
+  .md\:pb-0 {
+    @media (width >= 48rem) {
+      padding-bottom: calc(var(--spacing) * 0);
+    }
+  }
+}
+@layer components {
+  .striped {
+    background-color: #efefef;
+  }
+  .table th.center, .table td.center {
+    text-align: center;
+  }
+  .ri-icon {
+    vertical-align: -0.125em;
+    width: 1em;
+    height: 1em;
+    display: inline-block;
+  }
+  .ri-icon-green {
+    color: green;
+    font-size: 1em;
+  }
+  .ri-icon-red {
+    color: red;
+    font-size: 1em;
+  }
+  .ri-icon-yellow {
+    color: #d4a017;
+    font-size: 1em;
+  }
+  .debug_dump {
+    clear: both;
+    float: left;
+    background-color: #ddd7d7;
+    border-radius: 6px;
+    width: 100%;
+    margin-top: 45px;
+    padding: 10px;
+  }
+  .htmx-indicator {
+    opacity: 0;
+    transition: opacity 200ms ease-in;
+  }
+  .htmx-request .htmx-indicator, .htmx-request.htmx-indicator {
+    opacity: 1;
+  }
+}
+@layer base {
+  h1, h2, h3, h4, h5, h6 {
+    line-height: 1;
+  }
+  h1 {
+    letter-spacing: -2px;
+    text-align: center;
+    margin-bottom: 30px;
+    font-size: 3em;
+  }
+  h2 {
+    letter-spacing: -1px;
+    text-align: center;
+    color: #999;
+    margin-bottom: 30px;
+    font-size: 1.2em;
+    font-weight: 400;
+  }
+  p {
+    font-size: 1.1em;
+    line-height: 1.7em;
+  }
+  td, th {
+    padding: 0.5em 0.75em;
+  }
+  section {
+    overflow: auto;
+  }
+  textarea {
+    resize: vertical;
+  }
+}
+@property --tw-border-style {
+  syntax: "*";
+  inherits: false;
+  initial-value: solid;
+}
+@property --tw-font-weight {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-tracking {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-shadow {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0 0 #0000;
+}
+@property --tw-shadow-color {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-shadow-alpha {
+  syntax: "<percentage>";
+  inherits: false;
+  initial-value: 100%;
+}
+@property --tw-inset-shadow {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0 0 #0000;
+}
+@property --tw-inset-shadow-color {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-inset-shadow-alpha {
+  syntax: "<percentage>";
+  inherits: false;
+  initial-value: 100%;
+}
+@property --tw-ring-color {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-ring-shadow {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0 0 #0000;
+}
+@property --tw-inset-ring-color {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-inset-ring-shadow {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0 0 #0000;
+}
+@property --tw-ring-inset {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-ring-offset-width {
+  syntax: "<length>";
+  inherits: false;
+  initial-value: 0px;
+}
+@property --tw-ring-offset-color {
+  syntax: "*";
+  inherits: false;
+  initial-value: #fff;
+}
+@property --tw-ring-offset-shadow {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0 0 #0000;
+}
+@layer properties {
+  @supports ((-webkit-hyphens: none) and (not (margin-trim: inline))) or ((-moz-orient: inline) and (not (color:rgb(from red r g b)))) {
+    *, ::before, ::after, ::backdrop {
+      --tw-border-style: solid;
+      --tw-font-weight: initial;
+      --tw-tracking: initial;
+      --tw-shadow: 0 0 #0000;
+      --tw-shadow-color: initial;
+      --tw-shadow-alpha: 100%;
+      --tw-inset-shadow: 0 0 #0000;
+      --tw-inset-shadow-color: initial;
+      --tw-inset-shadow-alpha: 100%;
+      --tw-ring-color: initial;
+      --tw-ring-shadow: 0 0 #0000;
+      --tw-inset-ring-color: initial;
+      --tw-inset-ring-shadow: 0 0 #0000;
+      --tw-ring-inset: initial;
+      --tw-ring-offset-width: 0px;
+      --tw-ring-offset-color: #fff;
+      --tw-ring-offset-shadow: 0 0 #0000;
+    }
+  }
+}

--- a/src/main/resources/static/css/application.src.css
+++ b/src/main/resources/static/css/application.src.css
@@ -58,6 +58,16 @@
         margin-top: 45px;
         padding: 10px;
     }
+
+    .htmx-indicator {
+        opacity: 0;
+        transition: opacity 200ms ease-in;
+    }
+
+    .htmx-request .htmx-indicator,
+    .htmx-request.htmx-indicator {
+        opacity: 1;
+    }
 }
 
 @layer base {

--- a/src/main/resources/templates/clubs/index.html
+++ b/src/main/resources/templates/clubs/index.html
@@ -9,7 +9,8 @@
 <body>
 <th:block layout:fragment="content">
     <h1 class="text-2xl font-bold mt-3 mb-3">Vereinssuche</h1>
-    <form th:action="@{/clubs}" method="get" class="mb-3">
+    <form th:action="@{/clubs}" method="get" class="mb-3"
+          hx-get="/clubs" hx-target="#results" hx-indicator="#results-loading" hx-push-url="true">
         <div class="flex flex-wrap items-center gap-2">
             <input type="search" name="club" class="border border-gray-300 rounded px-2 py-1 text-sm"
                    placeholder="Vereinsname" th:value="${params != null ? params['club'] : ''}">
@@ -17,6 +18,10 @@
                     class="bg-brand text-white px-3 py-1 text-sm rounded hover:opacity-90 cursor-pointer">suchen</button>
         </div>
     </form>
+
+    <div id="results-loading" class="htmx-indicator text-gray-500 text-sm mt-2">Laden…</div>
+
+    <div id="results" th:fragment="results">
     <div th:if="${clubs == null}" class="rounded shadow mt-3">
         <header class="bg-gray-100 px-4 py-3 rounded-t font-semibold border-b border-gray-200">
             <span>Vereinssuche</span>
@@ -54,6 +59,7 @@
         </table>
     </div>
     <div th:if="${clubs != null and #lists.isEmpty(clubs)}">Es wurden keine Vereine gefunden.</div>
+    </div>
 </th:block>
 </body>
 </html>

--- a/src/main/resources/templates/layout.html
+++ b/src/main/resources/templates/layout.html
@@ -27,6 +27,9 @@
     <link rel="manifest" href="/manifest.json">
     <meta name="theme-color" content="#3e8ed0">
     <link rel="stylesheet" th:href="@{/css/application.css}">
+    <script defer src="https://unpkg.com/htmx.org@2.0.9/dist/htmx.min.js"
+            integrity="sha384-ESlCao+z/oasnu2Uc/5K1LQTI7YCF2KKO4xakCPQCFuiHhCh8Oa/R5NwHY6guZ3m"
+            crossorigin="anonymous"></script>
     <th:block layout:fragment="extra-head"></th:block>
 </head>
 <body>

--- a/src/main/resources/templates/listing/index.html
+++ b/src/main/resources/templates/listing/index.html
@@ -10,7 +10,8 @@
 <th:block layout:fragment="content">
 <main>
     <h1 class="text-2xl font-bold text-left mb-3 mt-3">Ranglisten</h1>
-    <form th:action="@{/listings}" method="get" class="mb-4">
+    <form th:action="@{/listings}" method="get" class="mb-4"
+          hx-get="/listings" hx-target="#results" hx-indicator="#results-loading" hx-push-url="true">
         <div class="flex flex-wrap items-start gap-3">
             <div>
                 <label for="quarter" class="block text-xs text-gray-500">Stichtag</label>
@@ -75,6 +76,9 @@
         </div>
     </form>
 
+    <div id="results-loading" class="htmx-indicator text-gray-500 text-sm mt-2">Laden…</div>
+
+    <div id="results" th:fragment="results">
     <div th:if="${rankings == null}" class="rounded shadow mt-3">
         <header class="bg-gray-100 px-4 py-3 rounded-t font-semibold border-b border-gray-200">
             <span>Ranglisten - Suchen und Filtern, auch in historischen Daten</span>
@@ -152,6 +156,7 @@
     </div>
     <div th:if="${rankings != null and #lists.isEmpty(rankings)}" class="mt-4 text-gray-600">
         Es wurden leider keine Daten für diese Suchkriterien gefunden.
+    </div>
     </div>
 </main>
 </th:block>

--- a/src/main/resources/templates/players/index.html
+++ b/src/main/resources/templates/players/index.html
@@ -9,7 +9,8 @@
 <body>
 <th:block layout:fragment="content">
     <h1 class="text-2xl font-bold text-left mb-3 mt-3">Spielersuche</h1>
-    <form th:action="@{/players}" method="get" class="mb-3">
+    <form th:action="@{/players}" method="get" class="mb-3"
+          hx-get="/players" hx-target="#results" hx-indicator="#results-loading" hx-push-url="true">
         <div class="flex flex-wrap items-center gap-2">
             <input type="search" name="dtb_id" class="border border-gray-300 rounded px-2 py-1 text-sm"
                    placeholder="DTB-ID" th:value="${params != null ? params['dtb_id'] : ''}">
@@ -21,6 +22,10 @@
                     class="bg-brand text-white px-3 py-1 text-sm rounded hover:opacity-90 cursor-pointer">suchen</button>
         </div>
     </form>
+
+    <div id="results-loading" class="htmx-indicator text-gray-500 text-sm mt-2">Laden…</div>
+
+    <div id="results" th:fragment="results">
     <div th:if="${players == null}" class="rounded shadow mt-3">
         <header class="bg-gray-100 px-4 py-3 rounded-t font-semibold border-b border-gray-200">
             <span>Spielersuche</span>
@@ -65,6 +70,7 @@
         </table>
     </div>
     <div th:if="${players != null and #lists.isEmpty(players)}">Es wurden keine Spieler gefunden.</div>
+    </div>
 </th:block>
 </body>
 </html>

--- a/src/test/java/de/hdawg/rankinginfo/web/ClubControllerTest.java
+++ b/src/test/java/de/hdawg/rankinginfo/web/ClubControllerTest.java
@@ -2,6 +2,7 @@ package de.hdawg.rankinginfo.web;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -40,5 +41,18 @@ class ClubControllerTest extends WebControllerTestBase {
   @DisplayName("GET club show for unknown club returns empty players")
   void getClubShowForUnknownClubReturnsEmptyPlayers() throws Exception {
     mockMvc.perform(get("/clubs/UNKNOWN CLUB")).andExpect(status().isOk());
+  }
+
+  @Test
+  @DisplayName("GET clubs with HX-Request header returns results fragment")
+  void getClubsWithHtmxHeaderReturnsFragment() throws Exception {
+    mockMvc
+        .perform(
+            get("/clubs")
+                .param("club", "Baden")
+                .param("commit", "1")
+                .header("HX-Request", "true"))
+        .andExpect(status().isOk())
+        .andExpect(view().name("clubs/index :: results"));
   }
 }

--- a/src/test/java/de/hdawg/rankinginfo/web/ListingControllerTest.java
+++ b/src/test/java/de/hdawg/rankinginfo/web/ListingControllerTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -118,5 +119,19 @@ class ListingControllerTest extends WebControllerTestBase {
                 .param("commit", "1"))
         .andExpect(status().isOk())
         .andExpect(model().attribute("rankings", hasSize(1)));
+  }
+
+  @Test
+  @DisplayName("GET listings with HX-Request header returns results fragment")
+  void getListingsWithHtmxHeaderReturnsFragment() throws Exception {
+    mockMvc
+        .perform(
+            get("/listings")
+                .param("quarter", q.toString())
+                .param("gender", "Herren")
+                .param("commit", "1")
+                .header("HX-Request", "true"))
+        .andExpect(status().isOk())
+        .andExpect(view().name("listing/index :: results"));
   }
 }

--- a/src/test/java/de/hdawg/rankinginfo/web/PlayerWebControllerTest.java
+++ b/src/test/java/de/hdawg/rankinginfo/web/PlayerWebControllerTest.java
@@ -1,7 +1,9 @@
 package de.hdawg.rankinginfo.web;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -73,5 +75,30 @@ class PlayerWebControllerTest extends WebControllerTestBase {
   @DisplayName("GET player show redirects for unknown player")
   void getPlayerShowRedirectsForUnknownPlayer() throws Exception {
     mockMvc.perform(get("/players/99999999")).andExpect(status().is3xxRedirection());
+  }
+
+  @Test
+  @DisplayName("GET players with HX-Request and multiple results returns fragment")
+  void getPlayersWithHtmxHeaderReturnsFragment() throws Exception {
+    rankingRepository.save(r(10_003_003, "Mueller", "Fritz", "m00", q, 3, "400", false, false));
+    mockMvc
+        .perform(
+            get("/players")
+                .param("lastname", "Mueller")
+                .header("HX-Request", "true"))
+        .andExpect(status().isOk())
+        .andExpect(view().name("players/index :: results"));
+  }
+
+  @Test
+  @DisplayName("GET players with HX-Request and single result sets HX-Redirect header")
+  void getPlayersWithHtmxSingleResultSetsRedirectHeader() throws Exception {
+    mockMvc
+        .perform(
+            get("/players")
+                .param("lastname", "Schmidt")
+                .header("HX-Request", "true"))
+        .andExpect(status().isOk())
+        .andExpect(header().string("HX-Redirect", "/players/10002002"));
   }
 }


### PR DESCRIPTION
## Summary

- Integrates htmx 2.0.9 (with SRI hash) into the layout to replace full page reloads on `/listings`, `/players` and `/clubs` with partial fragment swaps
- Controllers detect the `HX-Request` header and return only the results fragment instead of the full page; HTMX single-match redirects on `/players` use the `HX-Redirect` response header
- Forms retain their standard `action`/`method` attributes for graceful degradation without JavaScript
- Adds `.htmx-indicator` CSS rules for a subtle loading animation during requests

## Test plan

- [x] `mvn test` passes (124 tests, 0 failures)
- [x] `/listings` — filter absenden, nur Tabellenbereich aktualisiert sich (kein Page-Reload, Navigation bleibt stabil)
- [x] `/players` — Mehrfachtreffer zeigt Fragment, Einzeltreffer navigiert zur Player-Detailseite
- [x] `/clubs` — Suche aktualisiert nur die Ergebnisliste
- [x] URL-Bar aktualisiert sich korrekt nach jedem HTMX-Request (`hx-push-url`)
- [x] JavaScript deaktiviert → alle drei Seiten funktionieren weiterhin als normales HTML-Formular

🤖 Generated with [Claude Code](https://claude.com/claude-code)