### PR TITLE
fix federation overview missing youth and adult-only data

### DIFF
--- a/src/main/java/de/hdawg/rankinginfo/repository/RankingEntityRepository.java
+++ b/src/main/java/de/hdawg/rankinginfo/repository/RankingEntityRepository.java
@@ -29,7 +29,7 @@ interface RankingEntityRepository extends ListCrudRepository<RankingEntity, Long
           + " ORDER BY date ASC, age_group ASC")
   List<RankingEntity> findNonYearEndByDtbId(@Param("dtbId") Integer dtbId);
 
-  @Query("SELECT DISTINCT date FROM rankings WHERE date < :today ORDER BY date DESC")
+  @Query("SELECT DISTINCT date FROM rankings WHERE date <= :today ORDER BY date DESC")
   List<LocalDate> queryDistinctDatesDesc(@Param("today") LocalDate today);
 
   @Query("SELECT COUNT(DISTINCT dtb_id) FROM rankings WHERE dtb_id BETWEEN :start AND :end")

--- a/src/main/java/de/hdawg/rankinginfo/web/FederationController.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/FederationController.java
@@ -60,9 +60,7 @@ public class FederationController {
       for (var ag : new String[] {"m00", "w00"}) {
         for (var row : rankingRepository.countAdultByFederation(quarter, ag)) {
           var fed = FEDERATION_NAMES.getOrDefault(row.federation(), row.federation());
-          if (federations.containsKey(fed)) {
-            federations.get(fed).put(ag, (int) row.count());
-          }
+          federations.computeIfAbsent(fed, k -> new LinkedHashMap<>()).put(ag, (int) row.count());
         }
       }
     }


### PR DESCRIPTION
## Summary

- `queryDistinctDatesDesc` used `date < :today` — rankings imported on the current day were excluded, so `/federations` always showed the previous quarter's data
- `FederationController` adult loop used `containsKey` to gate `m00`/`w00` data — federations with no youth age-group ranking entries were silently dropped from the table entirely

## Root cause

Both bugs compounded: with the wrong quarter date, the youth query could return no results, making `containsKey` fail for every adult federation row as well, resulting in a completely empty or incomplete table.

## Test plan

- [ ] `mvn test` passes
- [ ] `/federations` shows data for all 17 Landesverbände including youth (U12–U18) and adult (Herren/Damen) columns
- [ ] On the day of a new import, the current quarter's data is shown (not the previous quarter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)