### PR TITLE
perf: inline SVG icons and pre-compute position changes in listing view

### DIFF
--- a/src/main/java/de/hdawg/rankinginfo/web/ListingController.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/ListingController.java
@@ -2,6 +2,7 @@ package de.hdawg.rankinginfo.web;
 
 import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -62,8 +63,16 @@ public class ListingController {
       var rankings = rankingService.findFilteredRankings(filter, 1, 1000);
       var dtbIds = rankings.getContent().stream().map(r -> r.dtbId()).toList();
       var prevPositions = rankingService.findPreviousPositions(filter, dtbIds);
+      var positionChanges = new HashMap<Integer, String>();
+      for (var r : rankings.getContent()) {
+        var prev = prevPositions.get(r.dtbId());
+        if (prev != null) {
+          if (prev > r.rankingPosition()) positionChanges.put(r.dtbId(), "up");
+          else if (prev < r.rankingPosition()) positionChanges.put(r.dtbId(), "down");
+        }
+      }
       model.addAttribute("rankings", rankings.getContent());
-      model.addAttribute("previousPositions", prevPositions);
+      model.addAttribute("positionChanges", Map.copyOf(positionChanges));
     }
     return htmxRequest != null ? "listing/index :: results" : "listing/index";
   }

--- a/src/main/resources/templates/listing/index.html
+++ b/src/main/resources/templates/listing/index.html
@@ -126,13 +126,13 @@
                 <td class="text-center py-1 px-2 hidden md:table-cell" th:text="${stat.index + 1}"></td>
                 <td class="py-1 px-2">
                     <span th:text="${r.rankingPosition}"></span>
-                    <th:block th:if="${previousPositions != null}">
-                        <th:block th:with="prev=${previousPositions.get(r.dtbId)}">
-                            <span th:if="${prev != null and prev > r.rankingPosition}" class="ri-icon-green" style="margin-left: 5px">
-                                <svg th:replace="~{fragments/icons :: arrow-up}"></svg>
+                    <th:block th:if="${positionChanges != null}">
+                        <th:block th:with="change=${positionChanges.get(r.dtbId)}">
+                            <span th:if="${change == 'up'}" class="ri-icon-green" style="margin-left: 5px">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512" fill="currentColor" aria-hidden="true" class="ri-icon" style="display:inline-block;"><path d="M182.6 137.4c-12.5-12.5-32.8-12.5-45.3 0l-128 128c-9.2 9.2-11.9 22.9-6.9 34.9s16.6 19.8 29.6 19.8l256 0c12.9 0 24.6-7.8 29.6-19.8s2.2-25.7-6.9-34.9l-128-128z"/></svg>
                             </span>
-                            <span th:if="${prev != null and prev < r.rankingPosition}" class="ri-icon-red" style="margin-left: 5px">
-                                <svg th:replace="~{fragments/icons :: arrow-down}"></svg>
+                            <span th:if="${change == 'down'}" class="ri-icon-red" style="margin-left: 5px">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512" fill="currentColor" aria-hidden="true" class="ri-icon" style="display:inline-block;"><path d="M137.4 374.6c12.5 12.5 32.8 12.5 45.3 0l128-128c9.2-9.2 11.9-22.9 6.9-34.9s-16.6-19.8-29.6-19.8L32 192c-12.9 0-24.6 7.8-29.6 19.8s-2.2 25.7 6.9 34.9l128 128z"/></svg>
                             </span>
                         </th:block>
                     </th:block>


### PR DESCRIPTION
## Summary

- Replaces `th:replace="~{fragments/icons :: arrow-up/down}"` with inline SVG markup, eliminating up to 2000 Thymeleaf fragment lookups per rendered listing (New Relic showed template rendering at ~94% of total response time)
- Pre-computes ranking position change direction (`"up"` / `"down"`) in the controller instead of evaluating Integer comparisons in the Thymeleaf expression language

## Test plan

- [ ] All 124 existing tests pass
- [ ] Spotless and PMD checks pass
- [ ] Verify arrow icons still render correctly for listings with position changes