### PR TITLE
perf: pre-compute view DTO and add Thymeleaf template warmup

### DIFF
--- a/src/main/java/de/hdawg/rankinginfo/web/ListingController.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/ListingController.java
@@ -1,8 +1,10 @@
 package de.hdawg.rankinginfo.web;
 
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -10,7 +12,9 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.util.UriUtils;
 
+import de.hdawg.rankinginfo.domain.Ranking;
 import de.hdawg.rankinginfo.service.RankingFilter;
 import de.hdawg.rankinginfo.service.RankingService;
 
@@ -61,20 +65,40 @@ public class ListingController {
           club,
           "1".equals(yearEnd));
       var rankings = rankingService.findFilteredRankings(filter, 1, 1000);
-      var dtbIds = rankings.getContent().stream().map(r -> r.dtbId()).toList();
+      var dtbIds = rankings.getContent().stream().map(Ranking::dtbId).toList();
       var prevPositions = rankingService.findPreviousPositions(filter, dtbIds);
-      var positionChanges = new HashMap<Integer, String>();
-      for (var r : rankings.getContent()) {
-        var prev = prevPositions.get(r.dtbId());
-        if (prev != null) {
-          if (prev > r.rankingPosition()) positionChanges.put(r.dtbId(), "up");
-          else if (prev < r.rankingPosition()) positionChanges.put(r.dtbId(), "down");
-        }
-      }
-      model.addAttribute("rankings", rankings.getContent());
-      model.addAttribute("positionChanges", Map.copyOf(positionChanges));
+      model.addAttribute("rankings", toRows(rankings.getContent(), prevPositions));
     }
     return htmxRequest != null ? "listing/index :: results" : "listing/index";
+  }
+
+  private static List<RankingRow> toRows(
+      List<Ranking> rankings, java.util.Map<Integer, Integer> prevPositions) {
+    var rows = new ArrayList<RankingRow>(rankings.size());
+    int rowNumber = 1;
+    for (var r : rankings) {
+      var prev = prevPositions.get(r.dtbId());
+      String positionChange = null;
+      if (prev != null) {
+        if (prev > r.rankingPosition()) positionChange = "up";
+        else if (prev < r.rankingPosition()) positionChange = "down";
+      }
+      rows.add(new RankingRow(
+          rowNumber,
+          r.rankingPosition(),
+          positionChange,
+          r.lastname() + ", " + r.firstname(),
+          String.valueOf(r.dtbId()),
+          "/players/" + r.dtbId(),
+          "/images/" + r.nationality().toLowerCase(Locale.ROOT) + ".svg",
+          r.nationality(),
+          r.club(),
+          "/clubs/" + UriUtils.encodePathSegment(r.club(), StandardCharsets.UTF_8),
+          r.federation(),
+          r.score()));
+      rowNumber++;
+    }
+    return rows;
   }
 
   private static String toAgeGroupSlug(String gender, String ageGroup) {

--- a/src/main/java/de/hdawg/rankinginfo/web/RankingRow.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/RankingRow.java
@@ -1,0 +1,17 @@
+package de.hdawg.rankinginfo.web;
+
+import org.jspecify.annotations.Nullable;
+
+public record RankingRow(
+    int rowNumber,
+    int rankingPosition,
+    @Nullable String positionChange,
+    String displayName,
+    String dtbId,
+    String playerUrl,
+    String flagSrc,
+    String nationality,
+    String club,
+    String clubUrl,
+    String federation,
+    String score) {}

--- a/src/main/java/de/hdawg/rankinginfo/web/ThymeleafWarmup.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/ThymeleafWarmup.java
@@ -1,0 +1,32 @@
+package de.hdawg.rankinginfo.web;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class ThymeleafWarmup implements ApplicationListener<ApplicationReadyEvent> {
+
+  private static final Logger log = LoggerFactory.getLogger(ThymeleafWarmup.class);
+
+  @Override
+  public void onApplicationEvent(ApplicationReadyEvent event) {
+    var port = event.getApplicationContext().getEnvironment().getProperty("local.server.port");
+    if (port == null) {
+      return;
+    }
+    log.info("Pre-warming Thymeleaf templates");
+    try {
+      new RestTemplate().getForObject("http://localhost:" + port + "/listings", String.class);
+      log.info("Thymeleaf template warmup complete");
+    } catch (RestClientException e) {
+      if (log.isWarnEnabled()) {
+        log.warn("Template warmup request failed: {}", e.getMessage());
+      }
+    }
+  }
+}

--- a/src/main/resources/templates/listing/index.html
+++ b/src/main/resources/templates/listing/index.html
@@ -122,31 +122,26 @@
             </tr>
             </thead>
             <tbody>
-            <tr th:each="r, stat : ${rankings}" class="border-b border-gray-200 even:bg-gray-50">
-                <td class="text-center py-1 px-2 hidden md:table-cell" th:text="${stat.index + 1}"></td>
+            <tr th:each="r : ${rankings}" class="border-b border-gray-200 even:bg-gray-50">
+                <td class="text-center py-1 px-2 hidden md:table-cell" th:text="${r.rowNumber}"></td>
                 <td class="py-1 px-2">
                     <span th:text="${r.rankingPosition}"></span>
-                    <th:block th:if="${positionChanges != null}">
-                        <th:block th:with="change=${positionChanges.get(r.dtbId)}">
-                            <span th:if="${change == 'up'}" class="ri-icon-green" style="margin-left: 5px">
-                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512" fill="currentColor" aria-hidden="true" class="ri-icon" style="display:inline-block;"><path d="M182.6 137.4c-12.5-12.5-32.8-12.5-45.3 0l-128 128c-9.2 9.2-11.9 22.9-6.9 34.9s16.6 19.8 29.6 19.8l256 0c12.9 0 24.6-7.8 29.6-19.8s2.2-25.7-6.9-34.9l-128-128z"/></svg>
-                            </span>
-                            <span th:if="${change == 'down'}" class="ri-icon-red" style="margin-left: 5px">
-                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512" fill="currentColor" aria-hidden="true" class="ri-icon" style="display:inline-block;"><path d="M137.4 374.6c12.5 12.5 32.8 12.5 45.3 0l128-128c9.2-9.2 11.9-22.9 6.9-34.9s-16.6-19.8-29.6-19.8L32 192c-12.9 0-24.6 7.8-29.6 19.8s-2.2 25.7 6.9 34.9l128 128z"/></svg>
-                            </span>
-                        </th:block>
-                    </th:block>
+                    <span th:if="${r.positionChange == 'up'}" class="ri-icon-green" style="margin-left: 5px">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512" fill="currentColor" aria-hidden="true" class="ri-icon" style="display:inline-block;"><path d="M182.6 137.4c-12.5-12.5-32.8-12.5-45.3 0l-128 128c-9.2 9.2-11.9 22.9-6.9 34.9s16.6 19.8 29.6 19.8l256 0c12.9 0 24.6-7.8 29.6-19.8s2.2-25.7-6.9-34.9l-128-128z"/></svg>
+                    </span>
+                    <span th:if="${r.positionChange == 'down'}" class="ri-icon-red" style="margin-left: 5px">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512" fill="currentColor" aria-hidden="true" class="ri-icon" style="display:inline-block;"><path d="M137.4 374.6c12.5 12.5 32.8 12.5 45.3 0l128-128c9.2-9.2 11.9-22.9 6.9-34.9s-16.6-19.8-29.6-19.8L32 192c-12.9 0-24.6 7.8-29.6 19.8s-2.2 25.7 6.9 34.9l128 128z"/></svg>
+                    </span>
                 </td>
-                <td class="py-1 px-2" th:text="${r.lastname + ', ' + r.firstname}"></td>
+                <td class="py-1 px-2" th:text="${r.displayName}"></td>
                 <td class="py-1 px-2">
-                    <a th:href="@{/players/{id}(id=${r.dtbId})}" class="text-brand" th:text="${r.dtbId}"></a>
+                    <a th:href="${r.playerUrl}" class="text-brand" th:text="${r.dtbId}"></a>
                 </td>
                 <td class="text-center py-1 px-2 hidden md:table-cell">
-                    <img th:src="@{/images/{nat}.svg(nat=${r.nationality.toLowerCase()})}"
-                         width="30" th:alt="${r.nationality}">
+                    <img th:src="${r.flagSrc}" width="30" th:alt="${r.nationality}">
                 </td>
                 <td class="py-1 px-2 hidden md:table-cell">
-                    <a th:href="@{/clubs/{name}(name=${r.club})}" class="text-brand" th:text="${r.club}"></a>
+                    <a th:href="${r.clubUrl}" class="text-brand" th:text="${r.club}"></a>
                 </td>
                 <td class="text-center py-1 px-2 hidden md:table-cell" th:text="${r.federation}"></td>
                 <td class="py-1 px-2" th:text="${r.score}"></td>


### PR DESCRIPTION
## Summary

- Introduces `RankingRow` view DTO that pre-computes all display strings (`displayName`, `playerUrl`, `clubUrl`, `flagSrc`) in Java before handing data to Thymeleaf. Eliminates ~7000 OGNL expression evaluations per 1000-row render, including the expensive `@{...}` URL-encoding expressions previously evaluated per cell in the template loop.
- Adds `ThymeleafWarmup` which fires an HTTP GET to `/listings` on `ApplicationReadyEvent`, so template parsing and JIT compilation happen at startup rather than on the first user request. Skips automatically when no real HTTP server is running (e.g. `@SpringBootTest` with mock servlet).

## Test plan

- [ ] All 124 existing tests pass
- [ ] Spotless and PMD checks pass
- [ ] Verify listing table renders correctly (name, links, flags, position arrows)
- [ ] Confirm startup log shows "Thymeleaf template warmup complete"