### PR TITLE
refactor: OpenCSV integration, service extraction, typed view-models, global exception handlers

### DIFF
--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -31,4 +31,16 @@
     <Class name="de.hdawg.rankinginfo.service.RankingFilter"/>
   </Match>
 
+  <!-- createdAt/updatedAt are written for DB INSERT and read by Spring Data JDBC via reflection -->
+  <Match>
+    <Bug pattern="URF_UNREAD_FIELD"/>
+    <Class name="de.hdawg.rankinginfo.persistence.RankingEntity"/>
+    <Field name="createdAt"/>
+  </Match>
+  <Match>
+    <Bug pattern="URF_UNREAD_FIELD"/>
+    <Class name="de.hdawg.rankinginfo.persistence.RankingEntity"/>
+    <Field name="updatedAt"/>
+  </Match>
+
 </FindBugsFilter>

--- a/src/main/java/de/hdawg/rankinginfo/api/security/RateLimitFilter.java
+++ b/src/main/java/de/hdawg/rankinginfo/api/security/RateLimitFilter.java
@@ -3,8 +3,6 @@ package de.hdawg.rankinginfo.api.security;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -12,6 +10,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import io.github.bucket4j.Bandwidth;
 import io.github.bucket4j.Bucket;
 import org.springframework.http.HttpStatus;
@@ -21,7 +21,8 @@ import org.springframework.web.filter.OncePerRequestFilter;
 public class RateLimitFilter extends OncePerRequestFilter {
 
   private final ObjectMapper objectMapper;
-  private final ConcurrentMap<String, Bucket> buckets = new ConcurrentHashMap<>();
+  private final Cache<String, Bucket> buckets =
+      Caffeine.newBuilder().expireAfterAccess(Duration.ofHours(2)).build();
 
   public RateLimitFilter(ObjectMapper objectMapper) {
     this.objectMapper = objectMapper;
@@ -38,7 +39,7 @@ public class RateLimitFilter extends OncePerRequestFilter {
       throws ServletException, IOException {
     var auth = request.getHeader("Authorization");
     var key = auth != null ? auth : request.getRemoteAddr();
-    var bucket = buckets.computeIfAbsent(key, k -> createBucket());
+    var bucket = buckets.get(key, k -> createBucket());
 
     if (bucket.tryConsume(1)) {
       filterChain.doFilter(request, response);

--- a/src/main/java/de/hdawg/rankinginfo/api/v1/GlobalApiExceptionHandler.java
+++ b/src/main/java/de/hdawg/rankinginfo/api/v1/GlobalApiExceptionHandler.java
@@ -1,0 +1,30 @@
+package de.hdawg.rankinginfo.api.v1;
+
+import java.util.NoSuchElementException;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice(basePackages = "de.hdawg.rankinginfo.api")
+public class GlobalApiExceptionHandler {
+
+  @ExceptionHandler({NoSuchElementException.class, IndexOutOfBoundsException.class})
+  @ResponseStatus(HttpStatus.NOT_FOUND)
+  public ErrorResponse handleNotFound(Exception e) {
+    return new ErrorResponse("Not Found");
+  }
+
+  @ExceptionHandler(IllegalArgumentException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  public ErrorResponse handleIllegalArgument(IllegalArgumentException e) {
+    return new ErrorResponse(e.getMessage());
+  }
+
+  @ExceptionHandler(Exception.class)
+  @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+  public ErrorResponse handleException(Exception e) {
+    return new ErrorResponse("Internal Server Error");
+  }
+}

--- a/src/main/java/de/hdawg/rankinginfo/config/ImportProperties.java
+++ b/src/main/java/de/hdawg/rankinginfo/config/ImportProperties.java
@@ -1,0 +1,6 @@
+package de.hdawg.rankinginfo.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "import")
+public record ImportProperties(String folder) {}

--- a/src/main/java/de/hdawg/rankinginfo/config/SecurityConfig.java
+++ b/src/main/java/de/hdawg/rankinginfo/config/SecurityConfig.java
@@ -16,7 +16,7 @@ import de.hdawg.rankinginfo.api.security.RateLimitFilter;
 
 @Configuration
 @EnableWebSecurity
-@EnableConfigurationProperties(ApiProperties.class)
+@EnableConfigurationProperties({ApiProperties.class, ImportProperties.class})
 public class SecurityConfig {
 
   @Bean

--- a/src/main/java/de/hdawg/rankinginfo/domain/Ranking.java
+++ b/src/main/java/de/hdawg/rankinginfo/domain/Ranking.java
@@ -1,7 +1,6 @@
 package de.hdawg.rankinginfo.domain;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 public record Ranking(
     long id,
@@ -17,6 +16,4 @@ public record Ranking(
     String federation,
     boolean ageGroupRanking,
     boolean yobRanking,
-    boolean yearEndRanking,
-    LocalDateTime createdAt,
-    LocalDateTime updatedAt) {}
+    boolean yearEndRanking) {}

--- a/src/main/java/de/hdawg/rankinginfo/persistence/RankingEntity.java
+++ b/src/main/java/de/hdawg/rankinginfo/persistence/RankingEntity.java
@@ -2,6 +2,7 @@ package de.hdawg.rankinginfo.persistence;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 
 import org.springframework.data.annotation.Id;
 import org.springframework.data.relational.core.mapping.Column;
@@ -63,6 +64,7 @@ public class RankingEntity {
   RankingEntity() {}
 
   public static RankingEntity fromDomain(Ranking r) {
+    var now = LocalDateTime.now(ZoneOffset.UTC);
     var e = new RankingEntity();
     if (r.id() != 0) {
       e.id = r.id();
@@ -80,8 +82,8 @@ public class RankingEntity {
     e.ageGroupRanking = r.ageGroupRanking();
     e.yobRanking = r.yobRanking();
     e.yearEndRanking = r.yearEndRanking();
-    e.createdAt = r.createdAt();
-    e.updatedAt = r.updatedAt();
+    e.createdAt = now;
+    e.updatedAt = now;
     return e;
   }
 
@@ -100,8 +102,6 @@ public class RankingEntity {
         federation,
         ageGroupRanking,
         yobRanking,
-        yearEndRanking,
-        createdAt,
-        updatedAt);
+        yearEndRanking);
   }
 }

--- a/src/main/java/de/hdawg/rankinginfo/repository/RankingRepository.java
+++ b/src/main/java/de/hdawg/rankinginfo/repository/RankingRepository.java
@@ -4,6 +4,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -23,21 +24,29 @@ import de.hdawg.rankinginfo.persistence.RankingEntity;
 @Repository
 public class RankingRepository {
 
-  private static final String BASE_FILTER_SQL =
-      "SELECT * FROM rankings"
-          + " WHERE date = :date AND age_group = :ageGroup"
-          + " AND dtb_id BETWEEN :dtbIdStart AND :dtbIdEnd"
-          + " AND yob_ranking = :yobRanking"
-          + " AND age_group_ranking = :ageGroupRanking"
-          + " AND year_end_ranking = :yearEndRanking";
+  private static final String RANKINGS_WHERE = """
+       WHERE date = :date AND age_group = :ageGroup
+         AND dtb_id BETWEEN :dtbIdStart AND :dtbIdEnd
+         AND yob_ranking = :yobRanking
+         AND age_group_ranking = :ageGroupRanking
+         AND year_end_ranking = :yearEndRanking""";
 
+  private static final String BASE_FILTER_SQL = "SELECT * FROM rankings " + RANKINGS_WHERE;
   private static final String BASE_FILTER_COUNT_SQL =
-      "SELECT COUNT(*) FROM rankings"
-          + " WHERE date = :date AND age_group = :ageGroup"
-          + " AND dtb_id BETWEEN :dtbIdStart AND :dtbIdEnd"
-          + " AND yob_ranking = :yobRanking"
-          + " AND age_group_ranking = :ageGroupRanking"
-          + " AND year_end_ranking = :yearEndRanking";
+      "SELECT COUNT(*) FROM rankings " + RANKINGS_WHERE;
+
+  private static final String BATCH_INSERT_SQL = """
+      INSERT INTO rankings
+        (dtb_id, lastname, firstname, nationality, age_group, date,
+         ranking_position, score, club, federation,
+         age_group_ranking, yob_ranking, year_end_ranking,
+         created_at, updated_at)
+      VALUES
+        (:dtbId, :lastname, :firstname, :nationality, :ageGroup, :date,
+         :rankingPosition, :score, :club, :federation,
+         :ageGroupRanking, :yobRanking, :yearEndRanking,
+         :createdAt, :updatedAt)
+      """;
 
   private static final RankingRowMapper ROW_MAPPER = new RankingRowMapper();
 
@@ -67,7 +76,27 @@ public class RankingRepository {
   }
 
   public void saveAll(List<Ranking> records) {
-    jdbc.saveAll(records.stream().map(RankingEntity::fromDomain).toList());
+    if (records.isEmpty()) return;
+    var now = LocalDateTime.now(ZoneOffset.UTC);
+    var params = records.stream()
+        .map(r -> new MapSqlParameterSource()
+            .addValue("dtbId", r.dtbId())
+            .addValue("lastname", r.lastname())
+            .addValue("firstname", r.firstname())
+            .addValue("nationality", r.nationality())
+            .addValue("ageGroup", r.ageGroup())
+            .addValue("date", r.date())
+            .addValue("rankingPosition", r.rankingPosition())
+            .addValue("score", r.score())
+            .addValue("club", r.club())
+            .addValue("federation", r.federation())
+            .addValue("ageGroupRanking", r.ageGroupRanking())
+            .addValue("yobRanking", r.yobRanking())
+            .addValue("yearEndRanking", r.yearEndRanking())
+            .addValue("createdAt", now)
+            .addValue("updatedAt", now))
+        .toArray(MapSqlParameterSource[]::new);
+    namedJdbc.batchUpdate(BATCH_INSERT_SQL, params);
   }
 
   public List<Ranking> findByDtbIdAndAgeGroupInOrderByDateDesc(int dtbId, List<String> ageGroups) {
@@ -242,9 +271,7 @@ public class RankingRepository {
           rs.getString("federation"),
           rs.getBoolean("age_group_ranking"),
           rs.getBoolean("yob_ranking"),
-          rs.getBoolean("year_end_ranking"),
-          rs.getObject("created_at", LocalDateTime.class),
-          rs.getObject("updated_at", LocalDateTime.class));
+          rs.getBoolean("year_end_ranking"));
     }
   }
 }

--- a/src/main/java/de/hdawg/rankinginfo/service/DuplicateImportError.java
+++ b/src/main/java/de/hdawg/rankinginfo/service/DuplicateImportError.java
@@ -1,0 +1,10 @@
+package de.hdawg.rankinginfo.service;
+
+public class DuplicateImportError extends Exception {
+
+  private static final long serialVersionUID = 1L;
+
+  public DuplicateImportError(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/de/hdawg/rankinginfo/service/ImportService.java
+++ b/src/main/java/de/hdawg/rankinginfo/service/ImportService.java
@@ -3,6 +3,7 @@ package de.hdawg.rankinginfo.service;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -16,6 +17,9 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
+import com.opencsv.CSVParserBuilder;
+import com.opencsv.CSVReaderBuilder;
+import com.opencsv.exceptions.CsvValidationException;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,7 +46,6 @@ public class ImportService {
       Map.of(CATEGORY_JUNIOREN, 100, CATEGORY_JUNIORINNEN, 200);
   private static final Map<String, String> AGE_GROUP_MAP =
       Map.of("herren", "m00", "damen", "w00", CATEGORY_JUNIOREN, "overall", CATEGORY_JUNIORINNEN, "overall");
-  private static final char CSV_QUOTE_CHAR = '"';
 
   private static final int CSV_COL_POSITION = 0;
   private static final int CSV_COL_LASTNAME = 1;
@@ -187,39 +190,47 @@ public class ImportService {
   private void storeFromCsv(Path file, LocalDate period, String ageGroup) throws IOException {
     var now = LocalDateTime.now(ZoneOffset.UTC);
     var records = new ArrayList<Ranking>();
-    try (var reader = Files.newBufferedReader(file, StandardCharsets.UTF_8)) {
-      var line = reader.readLine();
-      while (line != null) {
-        var parts = splitCsvLine(line);
-        if (parts.length >= CSV_MIN_COLS) {
-          var dtbParts = parts[CSV_COL_DTB_INFO].trim().split(" ");
-          if (dtbParts.length >= DTB_INFO_PARTS_MIN) {
-            var dtbId = parseIntOrNull(dtbParts[0]);
-            if (dtbId != null) {
-              records.add(
-                  new Ranking(
-                      0L,
-                      dtbId,
-                      parts[CSV_COL_LASTNAME].trim(),
-                      parts[CSV_COL_FIRSTNAME].trim(),
-                      parts[CSV_COL_NATIONALITY].trim().isEmpty()
-                          ? "nil"
-                          : parts[CSV_COL_NATIONALITY].trim(),
-                      ageGroup,
-                      period,
-                      parseIntOrZero(parts[CSV_COL_POSITION].trim()),
-                      stripQuotes(parts[CSV_COL_SCORE].trim()),
-                      stripQuotes(parts[CSV_COL_CLUB].trim()),
-                      dtbParts[1],
-                      false,
-                      false,
-                      false,
-                      now,
-                      now));
+    var csvParser = new CSVParserBuilder().withSeparator(',').withQuoteChar('"').build();
+    try (var reader =
+        new CSVReaderBuilder(
+                new InputStreamReader(Files.newInputStream(file), StandardCharsets.UTF_8))
+            .withCSVParser(csvParser)
+            .build()) {
+      try {
+        var parts = reader.readNext();
+        while (parts != null) {
+          if (parts.length >= CSV_MIN_COLS) {
+            var dtbParts = parts[CSV_COL_DTB_INFO].trim().split(" ");
+            if (dtbParts.length >= DTB_INFO_PARTS_MIN) {
+              var dtbId = parseIntOrNull(dtbParts[0]);
+              if (dtbId != null) {
+                records.add(
+                    new Ranking(
+                        0L,
+                        dtbId,
+                        parts[CSV_COL_LASTNAME].trim(),
+                        parts[CSV_COL_FIRSTNAME].trim(),
+                        parts[CSV_COL_NATIONALITY].trim().isEmpty()
+                            ? "nil"
+                            : parts[CSV_COL_NATIONALITY].trim(),
+                        ageGroup,
+                        period,
+                        parseIntOrZero(parts[CSV_COL_POSITION].trim()),
+                        parts[CSV_COL_SCORE].trim(),
+                        parts[CSV_COL_CLUB].trim(),
+                        dtbParts[1],
+                        false,
+                        false,
+                        false,
+                        now,
+                        now));
+              }
             }
           }
+          parts = reader.readNext();
         }
-        line = reader.readLine();
+      } catch (CsvValidationException e) {
+        throw new IOException("Failed to parse CSV: " + e.getMessage(), e);
       }
     }
     rankingRepository.saveAll(records);
@@ -323,24 +334,8 @@ public class ImportService {
     }
   }
 
-  private static String[] splitCsvLine(String line) {
-    var fields = new ArrayList<String>();
-    var field = new StringBuilder();
-    boolean inQuotes = false;
-    for (int i = 0; i < line.length(); i++) {
-      char c = line.charAt(i);
-      if (c == CSV_QUOTE_CHAR) {
-        inQuotes = !inQuotes;
-        field.append(c);
-      } else if (c == ',' && !inQuotes) {
-        fields.add(field.toString());
-        field.setLength(0);
-      } else {
-        field.append(c);
-      }
-    }
-    fields.add(field.toString());
-    return fields.toArray(String[]::new);
+  static String[] parseCsvLine(String line) throws IOException {
+    return new CSVParserBuilder().withSeparator(',').withQuoteChar('"').build().parseLine(line);
   }
 
   @Nullable
@@ -358,10 +353,5 @@ public class ImportService {
     } catch (NumberFormatException e) {
       return 0;
     }
-  }
-
-  private static String stripQuotes(String s) {
-    if (s.startsWith("\"") && s.endsWith("\"")) return s.substring(1, s.length() - 1);
-    return s;
   }
 }

--- a/src/main/java/de/hdawg/rankinginfo/service/ImportService.java
+++ b/src/main/java/de/hdawg/rankinginfo/service/ImportService.java
@@ -58,6 +58,7 @@ public class ImportService {
   private static final int FILENAME_PARTS_MIN = 2;
   private static final int DTB_INFO_PARTS_MIN = 2;
   private static final int JANUARY_MONTH = 1;
+  private static final int YOUNGEST_AGE_GROUP = 11;
 
   private final RankingRepository rankingRepository;
   private final ImportHistoryRepository importHistoryRepository;
@@ -66,14 +67,6 @@ public class ImportService {
       RankingRepository rankingRepository, ImportHistoryRepository importHistoryRepository) {
     this.rankingRepository = rankingRepository;
     this.importHistoryRepository = importHistoryRepository;
-  }
-
-  public static class DuplicateImportError extends Exception {
-    private static final long serialVersionUID = 1L;
-
-    public DuplicateImportError(String message) {
-      super(message);
-    }
   }
 
   public static LocalDate extractPeriodFromFilename(String filename) {
@@ -188,7 +181,6 @@ public class ImportService {
   }
 
   private void storeFromCsv(Path file, LocalDate period, String ageGroup) throws IOException {
-    var now = LocalDateTime.now(ZoneOffset.UTC);
     var records = new ArrayList<Ranking>();
     var csvParser = new CSVParserBuilder().withSeparator(',').withQuoteChar('"').build();
     try (var reader =
@@ -221,9 +213,7 @@ public class ImportService {
                         dtbParts[1],
                         false,
                         false,
-                        false,
-                        now,
-                        now));
+                        false));
               }
             }
           }
@@ -238,9 +228,9 @@ public class ImportService {
   }
 
   private void calculateRankings(LocalDate period, int genderFactor) {
-    var yobYoungest = String.valueOf(period.getYear() - 11);
+    var yobYoungest = String.valueOf(period.getYear() - YOUNGEST_AGE_GROUP);
 
-    for (int ageGroup = 11; ageGroup <= 18; ageGroup++) {
+    for (int ageGroup = YOUNGEST_AGE_GROUP; ageGroup <= 18; ageGroup++) {
       var yobsGeneral =
           yobRangeToFetch(yobYoungest, ageGroup, period, genderFactor).stream()
               .sorted()
@@ -248,15 +238,12 @@ public class ImportService {
       rankingsForAgeRange(yobsGeneral, period, ageGroup, false, false, false);
 
       int yobSingle =
-          Integer.parseInt(String.valueOf(period.getYear() - ageGroup).substring(2, 4))
-              + genderFactor;
+          (period.getYear() - ageGroup) % 100 + genderFactor;
       rankingsForAgeRange(List.of(yobSingle), period, ageGroup, true, false, false);
     }
 
     for (int ageGroup : List.of(12, 14, 16, 18)) {
-      int base =
-          Integer.parseInt(String.valueOf(period.getYear() - ageGroup).substring(2, 4))
-              + genderFactor;
+      int base = (period.getYear() - ageGroup) % 100 + genderFactor;
       var yobs = List.of(base, base + 1).stream().sorted().toList();
       rankingsForAgeRange(yobs, period, ageGroup, false, true, false);
     }
@@ -264,9 +251,7 @@ public class ImportService {
     if (period.getMonthValue() == JANUARY_MONTH) {
       var yeDate = period.minusDays(1);
       for (int ageGroup : List.of(12, 14, 16, 18)) {
-        int base =
-            Integer.parseInt(String.valueOf(yeDate.getYear() - ageGroup).substring(2, 4))
-                + genderFactor;
+        int base = (yeDate.getYear() - ageGroup) % 100 + genderFactor;
         var yobs = List.of(base, base + 1).stream().sorted().toList();
         rankingsForAgeRange(yobs, period, ageGroup, false, true, true);
       }
@@ -288,7 +273,6 @@ public class ImportService {
     int lastRank = 0;
     int startRanking = 0;
     int countUp = 1;
-    var now = LocalDateTime.now(ZoneOffset.UTC);
     var records = new ArrayList<Ranking>();
 
     for (var curr : rankingsFromDb) {
@@ -311,9 +295,7 @@ public class ImportService {
               curr.federation(),
               ageGroupRanking,
               yobRanking,
-              yearEndRanking,
-              now,
-              now));
+              yearEndRanking));
       if ("GER".equals(curr.nationality()) && !SPECIAL_SCORES.contains(curr.score())) {
         countUp++;
       }

--- a/src/main/java/de/hdawg/rankinginfo/service/PlayerService.java
+++ b/src/main/java/de/hdawg/rankinginfo/service/PlayerService.java
@@ -15,10 +15,29 @@ import de.hdawg.rankinginfo.repository.RankingRepository;
 @Transactional(readOnly = true)
 public class PlayerService {
 
+  private static final int DTB_ID_LENGTH = 8;
+
   private final RankingRepository rankingRepository;
 
   public PlayerService(RankingRepository rankingRepository) {
     this.rankingRepository = rankingRepository;
+  }
+
+  public int[] dtbIdRange(String dtbId) {
+    long idNum;
+    try {
+      idNum = Long.parseLong(dtbId.trim());
+    } catch (NumberFormatException e) {
+      idNum = 0L;
+    }
+    int missing = DTB_ID_LENGTH - Long.toString(idNum).length();
+    int start = (int) (idNum * Math.pow(10.0, missing));
+    int end = start + (int) Math.pow(10.0, missing) - 1;
+    return new int[] {start, end};
+  }
+
+  public int yobToMaleMarker(String yob) {
+    return Integer.parseInt(yob.trim().substring(2, 4)) + 100;
   }
 
   public Player loadPlayerProfile(int dtbId) {

--- a/src/main/java/de/hdawg/rankinginfo/service/RankingImportScheduler.java
+++ b/src/main/java/de/hdawg/rankinginfo/service/RankingImportScheduler.java
@@ -2,28 +2,29 @@ package de.hdawg.rankinginfo.service;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import de.hdawg.rankinginfo.config.ImportProperties;
+
+@SuppressWarnings("PMD.GuardLogStatement")
 @Component
 public class RankingImportScheduler {
 
   private static final Logger log = LoggerFactory.getLogger(RankingImportScheduler.class);
 
   private final ImportService importService;
+  private final ImportProperties importProperties;
 
-  @Value("${import.folder}")
-  private String importFolder;
-
-  public RankingImportScheduler(ImportService importService) {
+  public RankingImportScheduler(ImportService importService, ImportProperties importProperties) {
     this.importService = importService;
+    this.importProperties = importProperties;
   }
 
   @Scheduled(cron = "${import.schedule:0 0 12 * * ?}")
   public void runImport() {
-    log.info("Starting scheduled ranking import from '{}'", importFolder);
-    importService.scanAndImport(importFolder);
+    log.info("Starting scheduled ranking import from '{}'", importProperties.folder());
+    importService.scanAndImport(importProperties.folder());
     log.info("Scheduled ranking import completed");
   }
 }

--- a/src/main/java/de/hdawg/rankinginfo/service/RankingService.java
+++ b/src/main/java/de/hdawg/rankinginfo/service/RankingService.java
@@ -139,6 +139,22 @@ public class RankingService {
         null);
   }
 
+  public static String toAgeGroupSlug(String gender, @Nullable String ageGroup) {
+    return switch (gender) {
+      case "Herren" -> "m00";
+      case "Damen" -> "w00";
+      case "Junioren" ->
+          (ageGroup == null || ageGroup.isBlank())
+              ? "overall"
+              : "m" + ageGroup.toLowerCase(Locale.ROOT);
+      case "Juniorinnen" ->
+          (ageGroup == null || ageGroup.isBlank())
+              ? "overall"
+              : "w" + ageGroup.toLowerCase(Locale.ROOT);
+      default -> "overall";
+    };
+  }
+
   private static String slugToAgeGroup(String slug) {
     if (AGE_GROUP_M00.equals(slug)) return AGE_GROUP_M00;
     if (AGE_GROUP_W00.equals(slug)) return AGE_GROUP_W00;

--- a/src/main/java/de/hdawg/rankinginfo/service/RankingService.java
+++ b/src/main/java/de/hdawg/rankinginfo/service/RankingService.java
@@ -4,10 +4,11 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 import org.jspecify.annotations.Nullable;
@@ -48,7 +49,7 @@ public class RankingService {
 
   @Cacheable("available_quarters")
   public Map<String, List<QuarterEntry>> fetchAvailableQuarters() {
-    var years = new LinkedHashMap<String, List<QuarterEntry>>();
+    var years = new TreeMap<String, List<QuarterEntry>>(Comparator.reverseOrder());
     for (var date : rankingRepository.findDistinctDatesDesc()) {
       if (date.getMonthValue() == 12 && date.getDayOfMonth() == 31) continue;
       var adjusted = date.minusDays(1);
@@ -56,13 +57,7 @@ public class RankingService {
           .computeIfAbsent(String.valueOf(adjusted.getYear()), k -> new ArrayList<>())
           .add(new QuarterEntry(adjusted.format(DATE_FORMATTER), date.toString()));
     }
-    return years.entrySet().stream()
-        .sorted(
-            java.util.Comparator.comparingInt(
-                (Map.Entry<String, List<QuarterEntry>> e) -> -Integer.parseInt(e.getKey())))
-        .collect(
-            Collectors.toMap(
-                Map.Entry::getKey, Map.Entry::getValue, (a, b) -> a, LinkedHashMap::new));
+    return years;
   }
 
   @Cacheable("federations")

--- a/src/main/java/de/hdawg/rankinginfo/web/ClubController.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/ClubController.java
@@ -1,13 +1,6 @@
 package de.hdawg.rankinginfo.web;
 
-import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -17,19 +10,14 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
-import de.hdawg.rankinginfo.domain.Ranking;
-import de.hdawg.rankinginfo.repository.RankingRepository;
-
 @Controller
 @RequestMapping("/clubs")
 public class ClubController {
 
-  private static final Map<String, String> ADULT_LABELS = Map.of("m00", "Herren", "w00", "Damen");
+  private final ClubService clubService;
 
-  private final RankingRepository rankingRepository;
-
-  public ClubController(RankingRepository rankingRepository) {
-    this.rankingRepository = rankingRepository;
+  public ClubController(ClubService clubService) {
+    this.clubService = clubService;
   }
 
   @GetMapping
@@ -44,107 +32,15 @@ public class ClubController {
     model.addAttribute("params", params);
 
     if (commit != null && club != null && !club.isBlank()) {
-      var quarter = rankingRepository.findDistinctDatesDesc().stream().findFirst().orElse(null);
-      if (quarter != null) {
-        var youthByClub =
-            rankingRepository
-                .findByDateAndAgeGroupAndClubContaining(quarter, "overall", club)
-                .stream()
-                .collect(Collectors.groupingBy(Ranking::club));
-
-        var allAdults = new ArrayList<Ranking>();
-        allAdults.addAll(
-            rankingRepository.findByDateAndAgeGroupAndClubContaining(quarter, "m00", club));
-        allAdults.addAll(
-            rankingRepository.findByDateAndAgeGroupAndClubContaining(quarter, "w00", club));
-        var adultByClub = allAdults.stream().collect(Collectors.groupingBy(Ranking::club));
-
-        var clubs =
-            Stream.concat(youthByClub.keySet().stream(), adultByClub.keySet().stream())
-                .distinct()
-                .sorted()
-                .map(
-                    name ->
-                        Map.of(
-                            "name", name,
-                            "youth_count", youthByClub.getOrDefault(name, List.of()).size(),
-                            "adult_count", adultByClub.getOrDefault(name, List.of()).size()))
-                .toList();
-        model.addAttribute("clubs", clubs);
-      }
+      model.addAttribute("clubs", clubService.searchClubs(club));
     }
     return htmxRequest != null ? "clubs/index :: results" : "clubs/index";
   }
 
   @GetMapping("/{id}")
   public String show(@PathVariable String id, Model model) {
-    var quarter = rankingRepository.findDistinctDatesDesc().stream().findFirst().orElse(null);
-    var players = new LinkedHashMap<String, Object>();
-
-    if (quarter != null) {
-      var youth =
-          rankingRepository
-              .findByDateAndAgeGroupAndClubContaining(quarter, "overall", id)
-              .stream()
-              .filter(r -> r.club().equalsIgnoreCase(id))
-              .toList();
-
-      for (var entry : ADULT_LABELS.entrySet()) {
-        var ag = entry.getKey();
-        var label = entry.getValue();
-        var adults =
-            rankingRepository
-                .findByDateAndAgeGroupAndClubContaining(quarter, ag, id)
-                .stream()
-                .filter(r -> r.club().equalsIgnoreCase(id))
-                .toList();
-        if (!adults.isEmpty()) {
-          players.put(label, toPlayerMaps(adults, null));
-        }
-      }
-
-      var dtbIds = youth.stream().map(Ranking::dtbId).distinct().toList();
-      if (!dtbIds.isEmpty()) {
-        var ageGroupRankings =
-            rankingRepository
-                .findAgeGroupRankingsByDateAndDtbIds(quarter, dtbIds)
-                .stream()
-                .collect(Collectors.toMap(Ranking::dtbId, r -> r));
-        var grouped =
-            youth.stream()
-                .filter(r -> ageGroupRankings.containsKey(r.dtbId()))
-                .collect(Collectors.groupingBy(r -> ageGroupRankings.get(r.dtbId()).ageGroup()));
-
-        for (var ag : List.of("U12", "U14", "U16", "U18")) {
-          var group = grouped.get(ag);
-          if (group == null) continue;
-          var sorted = group.stream().sorted(Comparator.comparingInt(Ranking::rankingPosition)).toList();
-          players.put(ag, toPlayerMaps(sorted, ag));
-        }
-      }
-    }
-
     model.addAttribute("clubName", id);
-    model.addAttribute("players", players);
+    model.addAttribute("players", clubService.getClubDetail(id));
     return "clubs/show";
-  }
-
-  private static List<Map<String, Object>> toPlayerMaps(List<Ranking> rankings, String ageGroup) {
-    return rankings.stream()
-        .map(r -> buildPlayerMap(r, ageGroup))
-        .toList();
-  }
-
-  private static Map<String, Object> buildPlayerMap(Ranking r, String ageGroup) {
-    var map = new LinkedHashMap<String, Object>();
-    map.put("dtb_id", r.dtbId());
-    map.put("lastname", r.lastname());
-    map.put("firstname", r.firstname());
-    map.put("rank", r.rankingPosition());
-    map.put("score", r.score());
-    if (ageGroup != null) {
-      map.put("age", ageGroup);
-    }
-    return map;
   }
 }

--- a/src/main/java/de/hdawg/rankinginfo/web/ClubService.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/ClubService.java
@@ -1,0 +1,122 @@
+package de.hdawg.rankinginfo.web;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import de.hdawg.rankinginfo.domain.Ranking;
+import de.hdawg.rankinginfo.repository.RankingRepository;
+import de.hdawg.rankinginfo.web.viewmodel.ClubSummary;
+import de.hdawg.rankinginfo.web.viewmodel.PlayerSummaryRow;
+
+@Service
+@Transactional(readOnly = true)
+public class ClubService {
+
+  private static final String AGE_GROUP_OVERALL = "overall";
+  private static final String AGE_GROUP_M00 = "m00";
+  private static final String AGE_GROUP_W00 = "w00";
+  private static final Map<String, String> ADULT_LABELS = Map.of(AGE_GROUP_M00, "Herren", AGE_GROUP_W00, "Damen");
+
+  private final RankingRepository rankingRepository;
+
+  public ClubService(RankingRepository rankingRepository) {
+    this.rankingRepository = rankingRepository;
+  }
+
+  public List<ClubSummary> searchClubs(String searchTerm) {
+    var quarter = rankingRepository.findDistinctDatesDesc().stream().findFirst().orElse(null);
+    if (quarter == null) return List.of();
+
+    var youthByClub =
+        rankingRepository
+            .findByDateAndAgeGroupAndClubContaining(quarter, AGE_GROUP_OVERALL, searchTerm)
+            .stream()
+            .collect(Collectors.groupingBy(Ranking::club));
+
+    var allAdults = new ArrayList<Ranking>();
+    allAdults.addAll(
+        rankingRepository.findByDateAndAgeGroupAndClubContaining(quarter, AGE_GROUP_M00, searchTerm));
+    allAdults.addAll(
+        rankingRepository.findByDateAndAgeGroupAndClubContaining(quarter, AGE_GROUP_W00, searchTerm));
+    var adultByClub = allAdults.stream().collect(Collectors.groupingBy(Ranking::club));
+
+    return Stream.concat(youthByClub.keySet().stream(), adultByClub.keySet().stream())
+        .distinct()
+        .sorted()
+        .map(
+            name ->
+                new ClubSummary(
+                    name,
+                    youthByClub.getOrDefault(name, List.of()).size(),
+                    adultByClub.getOrDefault(name, List.of()).size()))
+        .toList();
+  }
+
+  public Map<String, List<PlayerSummaryRow>> getClubDetail(String clubId) {
+    var quarter = rankingRepository.findDistinctDatesDesc().stream().findFirst().orElse(null);
+    var players = new LinkedHashMap<String, List<PlayerSummaryRow>>();
+    if (quarter == null) return players;
+
+    for (var entry : ADULT_LABELS.entrySet()) {
+      var adults =
+          rankingRepository
+              .findByDateAndAgeGroupAndClubContaining(quarter, entry.getKey(), clubId)
+              .stream()
+              .filter(r -> r.club().equalsIgnoreCase(clubId))
+              .toList();
+      if (!adults.isEmpty()) {
+        players.put(entry.getValue(), toPlayerSummaryRows(adults, null));
+      }
+    }
+
+    var youth =
+        rankingRepository
+            .findByDateAndAgeGroupAndClubContaining(quarter, AGE_GROUP_OVERALL, clubId)
+            .stream()
+            .filter(r -> r.club().equalsIgnoreCase(clubId))
+            .toList();
+
+    var dtbIds = youth.stream().map(Ranking::dtbId).distinct().toList();
+    if (!dtbIds.isEmpty()) {
+      var ageGroupRankings =
+          rankingRepository
+              .findAgeGroupRankingsByDateAndDtbIds(quarter, dtbIds)
+              .stream()
+              .collect(Collectors.toMap(Ranking::dtbId, r -> r));
+      var grouped =
+          youth.stream()
+              .filter(r -> ageGroupRankings.containsKey(r.dtbId()))
+              .collect(
+                  Collectors.groupingBy(r -> ageGroupRankings.get(r.dtbId()).ageGroup()));
+
+      for (var ag : List.of("U12", "U14", "U16", "U18")) {
+        var group = grouped.get(ag);
+        if (group == null) continue;
+        var sorted =
+            group.stream().sorted(Comparator.comparingInt(Ranking::rankingPosition)).toList();
+        players.put(ag, toPlayerSummaryRows(sorted, ag));
+      }
+    }
+
+    return players;
+  }
+
+  private static List<PlayerSummaryRow> toPlayerSummaryRows(
+      List<Ranking> rankings, @Nullable String ageGroup) {
+    return rankings.stream()
+        .map(
+            r ->
+                new PlayerSummaryRow(
+                    r.dtbId(), r.lastname(), r.firstname(), r.rankingPosition(), r.score(), ageGroup))
+        .toList();
+  }
+}

--- a/src/main/java/de/hdawg/rankinginfo/web/FederationController.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/FederationController.java
@@ -1,71 +1,23 @@
 package de.hdawg.rankinginfo.web;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
-
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-import de.hdawg.rankinginfo.repository.RankingRepository;
-
 @Controller
 @RequestMapping("/federations")
 public class FederationController {
 
-  private static final Map<String, String> FEDERATION_NAMES =
-      Map.ofEntries(
-          Map.entry("BAD", "Baden"),
-          Map.entry("BB", "Berlin-Brandenburg"),
-          Map.entry("BTV", "Bayern"),
-          Map.entry("HAM", "Hamburg"),
-          Map.entry("HTV", "Hessen"),
-          Map.entry("RPF", "Rheinland-Pfalz"),
-          Map.entry("SLH", "Schleswig-Holstein"),
-          Map.entry("STB", "Saarland"),
-          Map.entry("STV", "Sachsen"),
-          Map.entry("TMV", "Mecklenburg-Vorpommern"),
-          Map.entry("TNB", "Niedersachsen-Bremen"),
-          Map.entry("TSA", "Sachsen-Anhalt"),
-          Map.entry("TTV", "Thüringen"),
-          Map.entry("TVM", "Mittelrhein"),
-          Map.entry("TVN", "Niederrhein"),
-          Map.entry("WTB", "Württemberg"),
-          Map.entry("WTV", "Westfalen"));
+  private final FederationService federationService;
 
-  private final RankingRepository rankingRepository;
-
-  public FederationController(RankingRepository rankingRepository) {
-    this.rankingRepository = rankingRepository;
+  public FederationController(FederationService federationService) {
+    this.federationService = federationService;
   }
 
   @GetMapping
   public String index(Model model) {
-    var quarter = rankingRepository.findDistinctDatesDesc().stream().findFirst().orElse(null);
-    var federations = new LinkedHashMap<String, Map<String, Integer>>();
-
-    if (quarter != null) {
-      for (var gender : new String[] {"m", "w"}) {
-        int dtbIdStart = "m".equals(gender) ? 10_000_000 : 20_000_000;
-        for (var row :
-            rankingRepository.countYouthByFederationAndAgeGroup(
-                quarter, dtbIdStart, dtbIdStart + 9_999_999)) {
-          var fed = FEDERATION_NAMES.getOrDefault(row.federation(), row.federation());
-          federations
-              .computeIfAbsent(fed, k -> new LinkedHashMap<>())
-              .put(row.ageGroup() + gender, (int) row.count());
-        }
-      }
-      for (var ag : new String[] {"m00", "w00"}) {
-        for (var row : rankingRepository.countAdultByFederation(quarter, ag)) {
-          var fed = FEDERATION_NAMES.getOrDefault(row.federation(), row.federation());
-          federations.computeIfAbsent(fed, k -> new LinkedHashMap<>()).put(ag, (int) row.count());
-        }
-      }
-    }
-
-    model.addAttribute("federations", federations);
+    model.addAttribute("federations", federationService.buildFederationData());
     return "federations/index";
   }
 }

--- a/src/main/java/de/hdawg/rankinginfo/web/FederationService.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/FederationService.java
@@ -1,0 +1,73 @@
+package de.hdawg.rankinginfo.web;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import de.hdawg.rankinginfo.repository.RankingRepository;
+
+@Service
+@Transactional(readOnly = true)
+public class FederationService {
+
+  private static final String GENDER_MALE = "m";
+  private static final String GENDER_FEMALE = "w";
+  private static final String AGE_GROUP_M00 = "m00";
+  private static final String AGE_GROUP_W00 = "w00";
+  private static final int MALE_DTB_ID_START = 10_000_000;
+  private static final int FEMALE_DTB_ID_START = 20_000_000;
+  private static final int DTB_RANGE_OFFSET = 9_999_999;
+
+  private static final Map<String, String> FEDERATION_NAMES =
+      Map.ofEntries(
+          Map.entry("BAD", "Baden"),
+          Map.entry("BB", "Berlin-Brandenburg"),
+          Map.entry("BTV", "Bayern"),
+          Map.entry("HAM", "Hamburg"),
+          Map.entry("HTV", "Hessen"),
+          Map.entry("RPF", "Rheinland-Pfalz"),
+          Map.entry("SLH", "Schleswig-Holstein"),
+          Map.entry("STB", "Saarland"),
+          Map.entry("STV", "Sachsen"),
+          Map.entry("TMV", "Mecklenburg-Vorpommern"),
+          Map.entry("TNB", "Niedersachsen-Bremen"),
+          Map.entry("TSA", "Sachsen-Anhalt"),
+          Map.entry("TTV", "Thüringen"),
+          Map.entry("TVM", "Mittelrhein"),
+          Map.entry("TVN", "Niederrhein"),
+          Map.entry("WTB", "Württemberg"),
+          Map.entry("WTV", "Westfalen"));
+
+  private final RankingRepository rankingRepository;
+
+  public FederationService(RankingRepository rankingRepository) {
+    this.rankingRepository = rankingRepository;
+  }
+
+  public Map<String, Map<String, Integer>> buildFederationData() {
+    var quarter = rankingRepository.findDistinctDatesDesc().stream().findFirst().orElse(null);
+    var federations = new LinkedHashMap<String, Map<String, Integer>>();
+    if (quarter == null) return federations;
+
+    for (var gender : new String[] {GENDER_MALE, GENDER_FEMALE}) {
+      int dtbIdStart = GENDER_MALE.equals(gender) ? MALE_DTB_ID_START : FEMALE_DTB_ID_START;
+      for (var row :
+          rankingRepository.countYouthByFederationAndAgeGroup(
+              quarter, dtbIdStart, dtbIdStart + DTB_RANGE_OFFSET)) {
+        var fed = FEDERATION_NAMES.getOrDefault(row.federation(), row.federation());
+        federations
+            .computeIfAbsent(fed, k -> new LinkedHashMap<>())
+            .put(row.ageGroup() + gender, (int) row.count());
+      }
+    }
+    for (var ag : new String[] {AGE_GROUP_M00, AGE_GROUP_W00}) {
+      for (var row : rankingRepository.countAdultByFederation(quarter, ag)) {
+        var fed = FEDERATION_NAMES.getOrDefault(row.federation(), row.federation());
+        federations.computeIfAbsent(fed, k -> new LinkedHashMap<>()).put(ag, (int) row.count());
+      }
+    }
+    return federations;
+  }
+}

--- a/src/main/java/de/hdawg/rankinginfo/web/GlobalWebExceptionHandler.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/GlobalWebExceptionHandler.java
@@ -1,0 +1,21 @@
+package de.hdawg.rankinginfo.web;
+
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+@ControllerAdvice(basePackages = "de.hdawg.rankinginfo.web")
+public class GlobalWebExceptionHandler {
+
+  @ExceptionHandler(IllegalArgumentException.class)
+  public String handleIllegalArgument(IllegalArgumentException e, RedirectAttributes redirect) {
+    redirect.addFlashAttribute("danger", e.getMessage());
+    return "redirect:/";
+  }
+
+  @ExceptionHandler(Exception.class)
+  public String handleException(Exception e, RedirectAttributes redirect) {
+    redirect.addFlashAttribute("danger", "Ein Fehler ist aufgetreten");
+    return "redirect:/";
+  }
+}

--- a/src/main/java/de/hdawg/rankinginfo/web/ListingController.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/ListingController.java
@@ -56,7 +56,7 @@ public class ListingController {
 
     if (commit != null && quarter != null && !quarter.isBlank()
         && gender != null && !gender.isBlank()) {
-      var slug = toAgeGroupSlug(gender, ageGroup);
+      var slug = RankingService.toAgeGroupSlug(gender, ageGroup);
       var filter = new RankingFilter(
           quarter,
           slug,
@@ -101,15 +101,4 @@ public class ListingController {
     return rows;
   }
 
-  private static String toAgeGroupSlug(String gender, String ageGroup) {
-    return switch (gender) {
-      case "Herren" -> "m00";
-      case "Damen" -> "w00";
-      case "Junioren" ->
-          (ageGroup == null || ageGroup.isBlank()) ? "overall" : "m" + ageGroup.toLowerCase(Locale.ROOT);
-      case "Juniorinnen" ->
-          (ageGroup == null || ageGroup.isBlank()) ? "overall" : "w" + ageGroup.toLowerCase(Locale.ROOT);
-      default -> "overall";
-    };
-  }
 }

--- a/src/main/java/de/hdawg/rankinginfo/web/PlayerController.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/PlayerController.java
@@ -86,7 +86,6 @@ public class PlayerController {
   }
 
   @GetMapping("/{id}")
-  @SuppressWarnings("PMD.AvoidCatchingGenericException")
   public String show(@PathVariable int id, Model model, RedirectAttributes redirect) {
     try {
       var player = playerService.loadPlayerProfile(id);
@@ -121,7 +120,7 @@ public class PlayerController {
       model.addAttribute("recent12mScoreData", recent12mDiagram.scores());
       model.addAttribute("availableData", availableData);
       return "players/show";
-    } catch (Exception e) {
+    } catch (IndexOutOfBoundsException e) {
       redirect.addFlashAttribute("danger", "Spieler nicht gefunden");
       return "redirect:/players";
     }

--- a/src/main/java/de/hdawg/rankinginfo/web/PlayerController.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/PlayerController.java
@@ -1,14 +1,6 @@
 package de.hdawg.rankinginfo.web;
 
-import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.TreeMap;
-import java.util.stream.Collectors;
 
 import jakarta.servlet.http.HttpServletResponse;
 
@@ -21,31 +13,27 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
-import de.hdawg.rankinginfo.domain.Ranking;
 import de.hdawg.rankinginfo.repository.RankingRepository;
 import de.hdawg.rankinginfo.service.PlayerService;
 
-@SuppressWarnings({"PMD.LooseCoupling", "PMD.AvoidLiteralsInIfCondition"})
+@SuppressWarnings("PMD.AvoidLiteralsInIfCondition")
 @Controller
 @RequestMapping("/players")
 public class PlayerController {
 
-  private static final Map<Integer, String> QUARTER_MAP =
-      Map.of(1, "Q1", 4, "Q2", 7, "Q3", 10, "Q4");
-  private static final List<String> ADULT_AGE_GROUPS = List.of("m00", "w00");
-  private static final List<String> DIAGRAM_AGE_GROUPS =
-      List.of("U12", "U14", "U16", "U18", "m00", "w00");
-  private static final int DTB_ID_LENGTH = 8;
-  private static final int DATE_PARTS_SIZE = 2;
   private static final String REDIRECT_PLAYER = "redirect:/players/";
   private static final String MODEL_PLAYERS = "players";
-  private static final DateTimeFormatter DTF = DateTimeFormatter.ofPattern("dd.MM.yyyy");
 
   private final PlayerService playerService;
+  private final PlayerProfileService playerProfileService;
   private final RankingRepository rankingRepository;
 
-  public PlayerController(PlayerService playerService, RankingRepository rankingRepository) {
+  public PlayerController(
+      PlayerService playerService,
+      PlayerProfileService playerProfileService,
+      RankingRepository rankingRepository) {
     this.playerService = playerService;
+    this.playerProfileService = playerProfileService;
     this.rankingRepository = rankingRepository;
   }
 
@@ -61,20 +49,12 @@ public class PlayerController {
       HttpServletResponse response) {
 
     if (dtbId != null && !dtbId.isBlank()) {
-      long idNum;
-      try {
-        idNum = Long.parseLong(dtbId.trim());
-      } catch (NumberFormatException e) {
-        idNum = 0L;
-      }
-      int missing = DTB_ID_LENGTH - Long.toString(idNum).length();
-      int start = (int) (idNum * Math.pow(10.0, missing));
-      int end = start + (int) Math.pow(10.0, missing) - 1;
-      var players = playerService.findPlayersByDtbIdRange(start, end);
+      var range = playerService.dtbIdRange(dtbId);
+      var players = playerService.findPlayersByDtbIdRange(range[0], range[1]);
       if (players.size() == 1) return redirectToPlayer(players.get(0).dtbId(), htmxRequest, response);
       model.addAttribute(MODEL_PLAYERS, players);
     } else if (lastname != null && !lastname.isBlank() && yob != null && !yob.isBlank()) {
-      int yobMale = Integer.parseInt(yob.trim().substring(2, 4)) + 100;
+      int yobMale = playerService.yobToMaleMarker(yob);
       var players = playerService.findPlayersByLastnameAndYob(lastname.trim(), yobMale, yobMale + 100);
       if (players.size() == 1) return redirectToPlayer(players.get(0).dtbId(), htmxRequest, response);
       model.addAttribute(MODEL_PLAYERS, players);
@@ -83,7 +63,7 @@ public class PlayerController {
       if (players.size() == 1) return redirectToPlayer(players.get(0).dtbId(), htmxRequest, response);
       model.addAttribute(MODEL_PLAYERS, players);
     } else if (yob != null && !yob.isBlank()) {
-      int yobMale = Integer.parseInt(yob.trim().substring(2, 4)) + 100;
+      int yobMale = playerService.yobToMaleMarker(yob);
       var players = playerService.findPlayersByYob(yobMale, yobMale + 100);
       if (players.size() == 1) return redirectToPlayer(players.get(0).dtbId(), htmxRequest, response);
       model.addAttribute(MODEL_PLAYERS, players);
@@ -123,140 +103,27 @@ public class PlayerController {
       var previousQuarter = allDates.size() > 1 ? allDates.get(1) : null;
       var recent4Dates = Set.copyOf(allDates.stream().limit(4).toList());
 
-      var currentRankings = buildCurrentRankings(rawRankings, currentQuarter, previousQuarter);
-      var allTimeDiagram = buildDiagramData(fullRankings);
-      var recent12mDiagram = buildDiagramData(
-          fullRankings.stream().filter(r -> recent4Dates.contains(r.date())).toList());
-      var completeRankings = buildCompleteRankings(fullRankings);
-      var availableData = buildAvailableData(completeRankings);
+      var currentRankings =
+          playerProfileService.buildCurrentRankings(rawRankings, currentQuarter, previousQuarter);
+      var allTimeDiagram = playerProfileService.buildDiagramData(fullRankings);
+      var recent12mDiagram =
+          playerProfileService.buildDiagramData(
+              fullRankings.stream().filter(r -> recent4Dates.contains(r.date())).toList());
+      var completeRankings = playerProfileService.buildCompleteRankings(fullRankings);
+      var availableData = playerProfileService.buildAvailableData(completeRankings);
 
       model.addAttribute("player", player);
       model.addAttribute("currentRankings", currentRankings);
       model.addAttribute("completeRankings", completeRankings);
-      model.addAttribute("diagramData", allTimeDiagram.get("positions"));
-      model.addAttribute("diagramScoreData", allTimeDiagram.get("scores"));
-      model.addAttribute("recent12mData", recent12mDiagram.get("positions"));
-      model.addAttribute("recent12mScoreData", recent12mDiagram.get("scores"));
+      model.addAttribute("diagramData", allTimeDiagram.positions());
+      model.addAttribute("diagramScoreData", allTimeDiagram.scores());
+      model.addAttribute("recent12mData", recent12mDiagram.positions());
+      model.addAttribute("recent12mScoreData", recent12mDiagram.scores());
       model.addAttribute("availableData", availableData);
       return "players/show";
     } catch (Exception e) {
       redirect.addFlashAttribute("danger", "Spieler nicht gefunden");
       return "redirect:/players";
-    }
-  }
-
-  private static List<Map<String, Object>> buildCurrentRankings(
-      List<Ranking> rawRankings,
-      java.time.LocalDate currentQuarter,
-      java.time.LocalDate previousQuarter) {
-    if (currentQuarter == null) return List.of();
-    return rawRankings.stream()
-        .filter(r -> r.date().equals(currentQuarter) && !"overall".equals(r.ageGroup()))
-        .map(r -> {
-          var prev = previousQuarter == null ? null
-              : rawRankings.stream()
-                  .filter(p -> p.date().equals(previousQuarter) && p.ageGroup().equals(r.ageGroup()))
-                  .findFirst().orElse(null);
-          var entry = new LinkedHashMap<String, Object>();
-          entry.put("age_group", r.ageGroup());
-          entry.put("position", r.rankingPosition());
-          entry.put("score", r.score());
-          entry.put("position_change", computePositionChange(prev, r));
-          entry.put("score_change", computeScoreChange(prev, r));
-          return (Map<String, Object>) entry;
-        })
-        .sorted(
-            Comparator.<Map<String, Object>, Integer>comparing(
-                    m -> ADULT_AGE_GROUPS.contains(m.get("age_group")) ? 0 : 1)
-                .thenComparing(m -> String.valueOf(m.get("age_group"))))
-        .toList();
-  }
-
-  private static List<Map<String, Object>> buildCompleteRankings(List<Ranking> rankings) {
-    var skipGroups = Set.of("overall");
-    var byDate = rankings.stream()
-        .filter(r -> !skipGroups.contains(r.ageGroup()))
-        .collect(Collectors.groupingBy(
-            Ranking::date,
-            () -> new TreeMap<>(Comparator.reverseOrder()),
-            Collectors.toList()));
-
-    var result = new ArrayList<Map<String, Object>>();
-    for (var entry : byDate.entrySet()) {
-      var date = entry.getKey();
-      var rows = entry.getValue();
-      var quarter = QUARTER_MAP.get(date.getMonthValue());
-      if (quarter == null) continue;
-      var map = new LinkedHashMap<String, Object>();
-      map.put("date", date.getYear() + "/" + quarter);
-      map.put("score", rows.isEmpty() ? "" : rows.get(0).score());
-      for (var r : rows) {
-        var key = ADULT_AGE_GROUPS.contains(r.ageGroup()) ? "Aktive" : r.ageGroup();
-        map.put(key, r.rankingPosition());
-      }
-      result.add(map);
-    }
-    return result;
-  }
-
-  private static Map<String, Object> buildDiagramData(List<Ranking> rankings) {
-    var positions = new LinkedHashMap<String, LinkedHashMap<String, Integer>>();
-    var scores = new LinkedHashMap<String, String>();
-    for (var r : rankings) {
-      if (!DIAGRAM_AGE_GROUPS.contains(r.ageGroup())) continue;
-      var groupKey = ADULT_AGE_GROUPS.contains(r.ageGroup()) ? "Aktive" : r.ageGroup();
-      var period = r.date().minusDays(1).format(DTF);
-      positions.computeIfAbsent(groupKey, k -> new LinkedHashMap<>()).put(period, r.rankingPosition());
-      scores.putIfAbsent(period, r.score());
-    }
-    var positionsList = List.of("U12", "U14", "U16", "U18", "Aktive").stream()
-        .filter(positions::containsKey)
-        .map(ag -> Map.of("name", ag, "data", (Object) positions.get(ag)))
-        .toList();
-    return Map.of(
-        "positions", positionsList,
-        "scores", List.of(Map.of("name", "Punkte", "data", (Object) scores)));
-  }
-
-  private static Map<Integer, Set<String>> buildAvailableData(List<Map<String, Object>> completeRankings) {
-    var result = new TreeMap<Integer, Set<String>>(Comparator.reverseOrder());
-    for (var row : completeRankings) {
-      var dateStr = (String) row.get("date");
-      if (dateStr == null) continue;
-      var parts = dateStr.split("/");
-      if (parts.length != DATE_PARTS_SIZE) continue;
-      int year;
-      try {
-        year = Integer.parseInt(parts[0]);
-      } catch (NumberFormatException e) {
-        continue;
-      }
-      result.computeIfAbsent(year, k -> new java.util.LinkedHashSet<>()).add(parts[1]);
-    }
-    return result;
-  }
-
-  private static String computePositionChange(Ranking prev, Ranking curr) {
-    if (prev == null) return null;
-    int diff = prev.rankingPosition() - curr.rankingPosition();
-    return diff > 0 ? "+" + diff : String.valueOf(diff);
-  }
-
-  private static String computeScoreChange(Ranking prev, Ranking curr) {
-    if (prev == null) return null;
-    try {
-      double currScore = Double.parseDouble(curr.score().replace(',', '.'));
-      double prevScore;
-      try {
-        prevScore = Double.parseDouble(prev.score().replace(',', '.'));
-      } catch (NumberFormatException e) {
-        prevScore = 0.0;
-      }
-      double diff = currScore - prevScore;
-      if (diff == 0.0) return null;
-      return diff > 0 ? "+" + diff : String.valueOf(diff);
-    } catch (NumberFormatException e) {
-      return null;
     }
   }
 }

--- a/src/main/java/de/hdawg/rankinginfo/web/PlayerProfileService.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/PlayerProfileService.java
@@ -1,0 +1,163 @@
+package de.hdawg.rankinginfo.web;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Service;
+
+import de.hdawg.rankinginfo.domain.Ranking;
+import de.hdawg.rankinginfo.web.viewmodel.AgeGroupTimeSeries;
+import de.hdawg.rankinginfo.web.viewmodel.CompleteRankingRow;
+import de.hdawg.rankinginfo.web.viewmodel.CurrentRankingRow;
+import de.hdawg.rankinginfo.web.viewmodel.DiagramDataView;
+import de.hdawg.rankinginfo.web.viewmodel.ScoreTimeSeries;
+
+@SuppressWarnings({"PMD.LooseCoupling", "PMD.AvoidLiteralsInIfCondition"})
+@Service
+public class PlayerProfileService {
+
+  private static final Map<Integer, String> QUARTER_MAP =
+      Map.of(1, "Q1", 4, "Q2", 7, "Q3", 10, "Q4");
+  private static final List<String> ADULT_AGE_GROUPS = List.of("m00", "w00");
+  private static final List<String> DIAGRAM_AGE_GROUPS =
+      List.of("U12", "U14", "U16", "U18", "m00", "w00");
+  private static final List<String> DIAGRAM_ORDER = List.of("U12", "U14", "U16", "U18", "Aktive");
+  private static final String AGE_GROUP_OVERALL = "overall";
+  private static final String AKTIVE_LABEL = "Aktive";
+  private static final int DATE_PARTS_SIZE = 2;
+  private static final DateTimeFormatter DTF = DateTimeFormatter.ofPattern("dd.MM.yyyy");
+
+  public List<CurrentRankingRow> buildCurrentRankings(
+      List<Ranking> rawRankings,
+      @Nullable LocalDate currentQuarter,
+      @Nullable LocalDate previousQuarter) {
+    if (currentQuarter == null) return List.of();
+    return rawRankings.stream()
+        .filter(r -> r.date().equals(currentQuarter) && !AGE_GROUP_OVERALL.equals(r.ageGroup()))
+        .map(
+            r -> {
+              var prev =
+                  previousQuarter == null
+                      ? null
+                      : rawRankings.stream()
+                          .filter(
+                              p ->
+                                  p.date().equals(previousQuarter)
+                                      && p.ageGroup().equals(r.ageGroup()))
+                          .findFirst()
+                          .orElse(null);
+              return new CurrentRankingRow(
+                  r.ageGroup(),
+                  r.rankingPosition(),
+                  r.score(),
+                  computePositionChange(prev, r),
+                  computeScoreChange(prev, r));
+            })
+        .sorted(
+            Comparator.<CurrentRankingRow, Integer>comparing(
+                    row -> ADULT_AGE_GROUPS.contains(row.ageGroup()) ? 0 : 1)
+                .thenComparing(CurrentRankingRow::ageGroup))
+        .toList();
+  }
+
+  public List<CompleteRankingRow> buildCompleteRankings(List<Ranking> rankings) {
+    var byDate =
+        rankings.stream()
+            .filter(r -> !AGE_GROUP_OVERALL.equals(r.ageGroup()))
+            .collect(
+                Collectors.groupingBy(
+                    Ranking::date,
+                    () -> new TreeMap<>(Comparator.reverseOrder()),
+                    Collectors.toList()));
+    var result = new ArrayList<CompleteRankingRow>();
+    for (var entry : byDate.entrySet()) {
+      var date = entry.getKey();
+      var rows = entry.getValue();
+      var quarter = QUARTER_MAP.get(date.getMonthValue());
+      if (quarter == null) continue;
+      var ageGroupPositions = new LinkedHashMap<String, Integer>();
+      for (var r : rows) {
+        var key = ADULT_AGE_GROUPS.contains(r.ageGroup()) ? AKTIVE_LABEL : r.ageGroup();
+        ageGroupPositions.put(key, r.rankingPosition());
+      }
+      result.add(
+          new CompleteRankingRow(
+              date.getYear() + "/" + quarter,
+              rows.isEmpty() ? "" : rows.get(0).score(),
+              ageGroupPositions));
+    }
+    return result;
+  }
+
+  public DiagramDataView buildDiagramData(List<Ranking> rankings) {
+    var positions = new LinkedHashMap<String, LinkedHashMap<String, Integer>>();
+    var scores = new LinkedHashMap<String, String>();
+    for (var r : rankings) {
+      if (!DIAGRAM_AGE_GROUPS.contains(r.ageGroup())) continue;
+      var groupKey = ADULT_AGE_GROUPS.contains(r.ageGroup()) ? AKTIVE_LABEL : r.ageGroup();
+      var period = r.date().minusDays(1).format(DTF);
+      positions
+          .computeIfAbsent(groupKey, k -> new LinkedHashMap<>())
+          .put(period, r.rankingPosition());
+      scores.putIfAbsent(period, r.score());
+    }
+    var positionsList =
+        DIAGRAM_ORDER.stream()
+            .filter(positions::containsKey)
+            .map(ag -> new AgeGroupTimeSeries(ag, positions.get(ag)))
+            .toList();
+    return new DiagramDataView(positionsList, List.of(new ScoreTimeSeries("Punkte", scores)));
+  }
+
+  @SuppressWarnings("PMD.EmptyCatchBlock")
+  public Map<Integer, Set<String>> buildAvailableData(List<CompleteRankingRow> completeRankings) {
+    var result = new TreeMap<Integer, Set<String>>(Comparator.reverseOrder());
+    for (var row : completeRankings) {
+      var parts = row.date().split("/");
+      if (parts.length != DATE_PARTS_SIZE) continue;
+      try {
+        var year = Integer.parseInt(parts[0]);
+        result.computeIfAbsent(year, k -> new LinkedHashSet<>()).add(parts[1]);
+      } catch (NumberFormatException e) {
+        // skip rows with unparseable year
+      }
+    }
+    return result;
+  }
+
+  @Nullable
+  private static String computePositionChange(@Nullable Ranking prev, Ranking curr) {
+    if (prev == null) return null;
+    int diff = prev.rankingPosition() - curr.rankingPosition();
+    return diff > 0 ? "+" + diff : String.valueOf(diff);
+  }
+
+  @Nullable
+  private static String computeScoreChange(@Nullable Ranking prev, Ranking curr) {
+    if (prev == null) return null;
+    try {
+      double currScore = Double.parseDouble(curr.score().replace(',', '.'));
+      double prevScore;
+      try {
+        prevScore = Double.parseDouble(prev.score().replace(',', '.'));
+      } catch (NumberFormatException e) {
+        prevScore = 0.0;
+      }
+      double diff = currScore - prevScore;
+      if (diff == 0.0) return null;
+      return diff > 0 ? "+" + diff : String.valueOf(diff);
+    } catch (NumberFormatException e) {
+      return null;
+    }
+  }
+}

--- a/src/main/java/de/hdawg/rankinginfo/web/viewmodel/AgeGroupTimeSeries.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/viewmodel/AgeGroupTimeSeries.java
@@ -2,4 +2,8 @@ package de.hdawg.rankinginfo.web.viewmodel;
 
 import java.util.Map;
 
-public record AgeGroupTimeSeries(String name, Map<String, Integer> data) {}
+public record AgeGroupTimeSeries(String name, Map<String, Integer> data) {
+  public AgeGroupTimeSeries {
+    data = Map.copyOf(data);
+  }
+}

--- a/src/main/java/de/hdawg/rankinginfo/web/viewmodel/AgeGroupTimeSeries.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/viewmodel/AgeGroupTimeSeries.java
@@ -1,0 +1,5 @@
+package de.hdawg.rankinginfo.web.viewmodel;
+
+import java.util.Map;
+
+public record AgeGroupTimeSeries(String name, Map<String, Integer> data) {}

--- a/src/main/java/de/hdawg/rankinginfo/web/viewmodel/ClubSummary.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/viewmodel/ClubSummary.java
@@ -1,0 +1,3 @@
+package de.hdawg.rankinginfo.web.viewmodel;
+
+public record ClubSummary(String name, int youthCount, int adultCount) {}

--- a/src/main/java/de/hdawg/rankinginfo/web/viewmodel/CompleteRankingRow.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/viewmodel/CompleteRankingRow.java
@@ -2,4 +2,8 @@ package de.hdawg.rankinginfo.web.viewmodel;
 
 import java.util.Map;
 
-public record CompleteRankingRow(String date, String score, Map<String, Integer> ageGroupPositions) {}
+public record CompleteRankingRow(String date, String score, Map<String, Integer> ageGroupPositions) {
+  public CompleteRankingRow {
+    ageGroupPositions = Map.copyOf(ageGroupPositions);
+  }
+}

--- a/src/main/java/de/hdawg/rankinginfo/web/viewmodel/CompleteRankingRow.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/viewmodel/CompleteRankingRow.java
@@ -1,0 +1,5 @@
+package de.hdawg.rankinginfo.web.viewmodel;
+
+import java.util.Map;
+
+public record CompleteRankingRow(String date, String score, Map<String, Integer> ageGroupPositions) {}

--- a/src/main/java/de/hdawg/rankinginfo/web/viewmodel/CurrentRankingRow.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/viewmodel/CurrentRankingRow.java
@@ -1,0 +1,10 @@
+package de.hdawg.rankinginfo.web.viewmodel;
+
+import org.jspecify.annotations.Nullable;
+
+public record CurrentRankingRow(
+    String ageGroup,
+    int position,
+    String score,
+    @Nullable String positionChange,
+    @Nullable String scoreChange) {}

--- a/src/main/java/de/hdawg/rankinginfo/web/viewmodel/DiagramDataView.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/viewmodel/DiagramDataView.java
@@ -2,4 +2,9 @@ package de.hdawg.rankinginfo.web.viewmodel;
 
 import java.util.List;
 
-public record DiagramDataView(List<AgeGroupTimeSeries> positions, List<ScoreTimeSeries> scores) {}
+public record DiagramDataView(List<AgeGroupTimeSeries> positions, List<ScoreTimeSeries> scores) {
+  public DiagramDataView {
+    positions = List.copyOf(positions);
+    scores = List.copyOf(scores);
+  }
+}

--- a/src/main/java/de/hdawg/rankinginfo/web/viewmodel/DiagramDataView.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/viewmodel/DiagramDataView.java
@@ -1,0 +1,5 @@
+package de.hdawg.rankinginfo.web.viewmodel;
+
+import java.util.List;
+
+public record DiagramDataView(List<AgeGroupTimeSeries> positions, List<ScoreTimeSeries> scores) {}

--- a/src/main/java/de/hdawg/rankinginfo/web/viewmodel/PlayerSummaryRow.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/viewmodel/PlayerSummaryRow.java
@@ -1,0 +1,11 @@
+package de.hdawg.rankinginfo.web.viewmodel;
+
+import org.jspecify.annotations.Nullable;
+
+public record PlayerSummaryRow(
+    int dtbId,
+    String lastname,
+    String firstname,
+    int rank,
+    String score,
+    @Nullable String ageGroup) {}

--- a/src/main/java/de/hdawg/rankinginfo/web/viewmodel/ScoreTimeSeries.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/viewmodel/ScoreTimeSeries.java
@@ -1,0 +1,5 @@
+package de.hdawg.rankinginfo.web.viewmodel;
+
+import java.util.Map;
+
+public record ScoreTimeSeries(String name, Map<String, String> data) {}

--- a/src/main/java/de/hdawg/rankinginfo/web/viewmodel/ScoreTimeSeries.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/viewmodel/ScoreTimeSeries.java
@@ -2,4 +2,8 @@ package de.hdawg.rankinginfo.web.viewmodel;
 
 import java.util.Map;
 
-public record ScoreTimeSeries(String name, Map<String, String> data) {}
+public record ScoreTimeSeries(String name, Map<String, String> data) {
+  public ScoreTimeSeries {
+    data = Map.copyOf(data);
+  }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -4,6 +4,8 @@ spring:
     driver-class-name: org.h2.Driver
   liquibase:
     change-log: classpath:db/changelog/db.changelog-master.yaml
+  thymeleaf:
+    cache: false
 
 import:
   folder: ${IMPORT_FOLDER:${user.home}/ranking-import}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -7,6 +7,8 @@ spring:
     hikari:
       maximum-pool-size: 5
       minimum-idle: 2
+  thymeleaf:
+    cache: false
 
 import:
   schedule: "${IMPORT_SCHEDULE:0 */5 * * * ?}"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,8 +9,6 @@ spring:
     type: caffeine
     caffeine:
       spec: maximumSize=500,expireAfterWrite=1h
-  thymeleaf:
-    cache: false
   security:
     user:
       password: disabled

--- a/src/main/resources/templates/clubs/index.html
+++ b/src/main/resources/templates/clubs/index.html
@@ -49,11 +49,11 @@
             <tbody>
             <tr th:each="club : ${clubs}" class="border-b border-gray-200 even:bg-gray-50">
                 <td class="py-1 px-2">
-                    <a th:href="@{/clubs/{name}(name=${club['name']})}" class="text-brand"
-                       th:text="${club['name']}"></a>
+                    <a th:href="@{/clubs/{name}(name=${club.name})}" class="text-brand"
+                       th:text="${club.name}"></a>
                 </td>
-                <td class="py-1 px-2 text-center" th:text="${club['youth_count']}"></td>
-                <td class="py-1 px-2 text-center" th:text="${club['adult_count']}"></td>
+                <td class="py-1 px-2 text-center" th:text="${club.youthCount}"></td>
+                <td class="py-1 px-2 text-center" th:text="${club.adultCount}"></td>
             </tr>
             </tbody>
         </table>

--- a/src/main/resources/templates/clubs/show.html
+++ b/src/main/resources/templates/clubs/show.html
@@ -24,12 +24,12 @@
             <tbody>
             <tr th:each="p : ${entry.value}" class="border-b border-gray-200 even:bg-gray-50">
                 <td class="py-1 px-2">
-                    <a th:href="@{/players/{id}(id=${p['dtb_id']})}" class="text-brand"
-                       th:text="${p['dtb_id']}"></a>
+                    <a th:href="@{/players/{id}(id=${p.dtbId})}" class="text-brand"
+                       th:text="${p.dtbId}"></a>
                 </td>
-                <td class="py-1 px-2" th:text="${p['lastname'] + ', ' + p['firstname']}"></td>
-                <td class="py-1 px-2 text-center" th:text="${p['rank']}"></td>
-                <td class="py-1 px-2 text-center" th:text="${p['score']}"></td>
+                <td class="py-1 px-2" th:text="${p.lastname + ', ' + p.firstname}"></td>
+                <td class="py-1 px-2 text-center" th:text="${p.rank}"></td>
+                <td class="py-1 px-2 text-center" th:text="${p.score}"></td>
             </tr>
             </tbody>
         </table>

--- a/src/main/resources/templates/players/show.html
+++ b/src/main/resources/templates/players/show.html
@@ -43,12 +43,12 @@
                         <th scope="col" class="py-2 px-2"></th>
                     </tr>
                     <tr th:each="r : ${currentRankings}"
-                        th:classappend="${r['age_group'] == 'm00' or r['age_group'] == 'w00'} ? 'border-b border-gray-200 bg-blue-50' : 'border-b border-gray-200'">
+                        th:classappend="${r.ageGroup == 'm00' or r.ageGroup == 'w00'} ? 'border-b border-gray-200 bg-blue-50' : 'border-b border-gray-200'">
                         <td class="text-center py-1 px-2"
-                            th:text="${r['age_group'] == 'm00' or r['age_group'] == 'w00' ? 'Aktive' : r['age_group']}"></td>
-                        <td class="py-1 px-2" th:text="${r['position']}"></td>
+                            th:text="${r.ageGroup == 'm00' or r.ageGroup == 'w00' ? 'Aktive' : r.ageGroup}"></td>
+                        <td class="py-1 px-2" th:text="${r.position}"></td>
                         <td class="py-1 px-2">
-                            <th:block th:with="pc=${r['position_change']}">
+                            <th:block th:with="pc=${r.positionChange}">
                                 <span th:if="${pc == null or pc == '0'}">
                                     <svg th:replace="~{fragments/icons :: neutral}"></svg>
                                 </span>
@@ -60,9 +60,9 @@
                                 </span>
                             </th:block>
                         </td>
-                        <td class="py-1 px-2" th:text="${r['score']}"></td>
+                        <td class="py-1 px-2" th:text="${r.score}"></td>
                         <td class="py-1 px-2">
-                            <th:block th:with="sc=${r['score_change']}">
+                            <th:block th:with="sc=${r.scoreChange}">
                                 <span th:if="${sc != null and #strings.startsWith(sc, '+')}" class="ri-icon-green">
                                     <svg th:replace="~{fragments/icons :: arrow-up}"></svg>
                                 </span>
@@ -189,17 +189,17 @@
                 </div>
                 <div th:each="r, stat : ${completeRankings}"
                      th:class="${'grid grid-cols-12 border-b border-gray-200 min-w-max ' + (stat.odd ? 'striped' : '')}">
-                    <div class="col-span-2 py-1 px-1" th:text="${r['date']}"></div>
-                    <div class="col-span-1 py-1 px-1" th:text="${r['score']}"></div>
-                    <div class="col-span-1 py-1 px-1" th:text="${r['U11'] ?: ''}"></div>
-                    <div class="col-span-1 py-1 px-1" th:text="${r['U12'] ?: ''}"></div>
-                    <div class="col-span-1 py-1 px-1" th:text="${r['U13'] ?: ''}"></div>
-                    <div class="col-span-1 py-1 px-1" th:text="${r['U14'] ?: ''}"></div>
-                    <div class="col-span-1 py-1 px-1" th:text="${r['U15'] ?: ''}"></div>
-                    <div class="col-span-1 py-1 px-1" th:text="${r['U16'] ?: ''}"></div>
-                    <div class="col-span-1 py-1 px-1" th:text="${r['U17'] ?: ''}"></div>
-                    <div class="col-span-1 py-1 px-1" th:text="${r['U18'] ?: ''}"></div>
-                    <div class="col-span-1 py-1 px-1" th:text="${r['Aktive'] ?: ''}"></div>
+                    <div class="col-span-2 py-1 px-1" th:text="${r.date}"></div>
+                    <div class="col-span-1 py-1 px-1" th:text="${r.score}"></div>
+                    <div class="col-span-1 py-1 px-1" th:text="${r.ageGroupPositions['U11'] ?: ''}"></div>
+                    <div class="col-span-1 py-1 px-1" th:text="${r.ageGroupPositions['U12'] ?: ''}"></div>
+                    <div class="col-span-1 py-1 px-1" th:text="${r.ageGroupPositions['U13'] ?: ''}"></div>
+                    <div class="col-span-1 py-1 px-1" th:text="${r.ageGroupPositions['U14'] ?: ''}"></div>
+                    <div class="col-span-1 py-1 px-1" th:text="${r.ageGroupPositions['U15'] ?: ''}"></div>
+                    <div class="col-span-1 py-1 px-1" th:text="${r.ageGroupPositions['U16'] ?: ''}"></div>
+                    <div class="col-span-1 py-1 px-1" th:text="${r.ageGroupPositions['U17'] ?: ''}"></div>
+                    <div class="col-span-1 py-1 px-1" th:text="${r.ageGroupPositions['U18'] ?: ''}"></div>
+                    <div class="col-span-1 py-1 px-1" th:text="${r.ageGroupPositions['Aktive'] ?: ''}"></div>
                 </div>
             </div>
         </div>

--- a/src/test/java/de/hdawg/rankinginfo/api/GlobalApiExceptionHandlerTest.java
+++ b/src/test/java/de/hdawg/rankinginfo/api/GlobalApiExceptionHandlerTest.java
@@ -1,0 +1,38 @@
+package de.hdawg.rankinginfo.api;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class GlobalApiExceptionHandlerTest {
+
+  @Autowired MockMvc mockMvc;
+
+  private static final String AUTH = "Bearer test-api-token";
+
+  @Test
+  @DisplayName("invalid date in listings path triggers 500 with error JSON body")
+  void invalidDateReturns500WithErrorBody() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/listings/not-a-date/m00").header("Authorization", AUTH))
+        .andExpect(status().isInternalServerError())
+        .andExpect(jsonPath("$.error").value("Internal Server Error"));
+  }
+
+  @Test
+  @DisplayName("valid request to listings with no data returns 200 (handler is not invoked)")
+  void validRequestDoesNotTriggerHandler() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/listings/2099-01-01/m00").header("Authorization", AUTH))
+        .andExpect(status().isOk());
+  }
+}

--- a/src/test/java/de/hdawg/rankinginfo/api/ListingsApiControllerTest.java
+++ b/src/test/java/de/hdawg/rankinginfo/api/ListingsApiControllerTest.java
@@ -7,7 +7,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 
 import org.junit.jupiter.api.AfterEach;
@@ -33,8 +32,6 @@ class ListingsApiControllerTest {
 
   @Autowired ImportHistoryRepository importHistoryRepository;
 
-  private static final LocalDateTime NOW = LocalDateTime.of(2026, 1, 1, 0, 0);
-
   private final String quarter = "2026-04-01";
   private final String prevQuarter = "2026-01-01";
   private final String auth = "Bearer test-api-token";
@@ -43,15 +40,14 @@ class ListingsApiControllerTest {
   void seed() {
     var q = LocalDate.parse(quarter);
     var pq = LocalDate.parse(prevQuarter);
-    var now = NOW;
 
     rankingRepository.saveAll(
         List.of(
-            ranking(10_001_001, "Mueller", "Hans", "m00", q, 1, "500", false, false, now),
-            ranking(10_002_002, "Schmidt", "Peter", "m00", q, 2, "490", false, false, now),
-            ranking(10_003_003, "Wagner", "Karl", "m00", q, 3, "480", false, false, now),
-            ranking(10_001_001, "Mueller", "Hans", "m00", pq, 3, "460", false, false, now),
-            ranking(20_001_001, "Meyer", "Anna", "w00", q, 1, "500", false, false, now)));
+            ranking(10_001_001, "Mueller", "Hans", "m00", q, 1, "500", false, false),
+            ranking(10_002_002, "Schmidt", "Peter", "m00", q, 2, "490", false, false),
+            ranking(10_003_003, "Wagner", "Karl", "m00", q, 3, "480", false, false),
+            ranking(10_001_001, "Mueller", "Hans", "m00", pq, 3, "460", false, false),
+            ranking(20_001_001, "Meyer", "Anna", "w00", q, 1, "500", false, false)));
   }
 
   @AfterEach
@@ -254,10 +250,9 @@ class ListingsApiControllerTest {
       int pos,
       String score,
       boolean ageGroupRanking,
-      boolean yobRanking,
-      LocalDateTime now) {
+      boolean yobRanking) {
     return new Ranking(
         0L, dtbId, lastname, firstname, "GER", ageGroup, date, pos, score,
-        "TC Test", "TST", ageGroupRanking, yobRanking, false, now, now);
+        "TC Test", "TST", ageGroupRanking, yobRanking, false);
   }
 }

--- a/src/test/java/de/hdawg/rankinginfo/api/PlayersApiControllerTest.java
+++ b/src/test/java/de/hdawg/rankinginfo/api/PlayersApiControllerTest.java
@@ -5,7 +5,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 
 import org.junit.jupiter.api.AfterEach;
@@ -30,8 +29,6 @@ class PlayersApiControllerTest {
   @Autowired RankingRepository rankingRepository;
 
   @Autowired ImportHistoryRepository importHistoryRepository;
-
-  private static final LocalDateTime NOW = LocalDateTime.of(2026, 1, 1, 0, 0);
 
   private final String auth = "Bearer test-api-token";
   private final LocalDate q = LocalDate.of(2026, 4, 1);
@@ -211,7 +208,6 @@ class PlayersApiControllerTest {
       boolean yobRanking) {
     return new Ranking(
         0L, dtbId, lastname, firstname, "GER", ageGroup, date, pos, "100",
-        "TC Test", "TST", ageGroupRanking, yobRanking, false,
-        NOW, NOW);
+        "TC Test", "TST", ageGroupRanking, yobRanking, false);
   }
 }

--- a/src/test/java/de/hdawg/rankinginfo/service/CsvParsingTest.java
+++ b/src/test/java/de/hdawg/rankinginfo/service/CsvParsingTest.java
@@ -1,0 +1,45 @@
+package de.hdawg.rankinginfo.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CsvParsingTest {
+
+  @Test
+  @DisplayName("simple row without quotes is split on commas")
+  void simpleRowWithoutQuotes() throws IOException {
+    var line = "1,Mustermann,Max,GER,10234567 HH,TC Hamburg,850";
+    var parts = ImportService.parseCsvLine(line);
+    assertEquals(7, parts.length);
+    assertEquals("1", parts[0]);
+    assertEquals("Mustermann", parts[1]);
+    assertEquals("Max", parts[2]);
+    assertEquals("GER", parts[3]);
+    assertEquals("10234567 HH", parts[4]);
+    assertEquals("TC Hamburg", parts[5]);
+    assertEquals("850", parts[6]);
+  }
+
+  @Test
+  @DisplayName("quoted decimal score is delivered without surrounding quotes")
+  void quotedDecimalScore() throws IOException {
+    var line = "3,Schmidt,Anna,GER,20345678 BY,SC München,\"66,9\"";
+    var parts = ImportService.parseCsvLine(line);
+    assertEquals(7, parts.length);
+    assertEquals("66,9", parts[6]);
+  }
+
+  @Test
+  @DisplayName("club name with internal comma inside quotes is not split")
+  void clubNameWithCommaInsideQuotes() throws IOException {
+    var line = "5,Weber,Klaus,GER,10567890 NRW,\"TC Rot-Weiss, Köln\",720";
+    var parts = ImportService.parseCsvLine(line);
+    assertEquals(7, parts.length);
+    assertEquals("TC Rot-Weiss, Köln", parts[5]);
+    assertEquals("720", parts[6]);
+  }
+}

--- a/src/test/java/de/hdawg/rankinginfo/service/ImportIntegrationTest.java
+++ b/src/test/java/de/hdawg/rankinginfo/service/ImportIntegrationTest.java
@@ -101,7 +101,7 @@ class ImportIntegrationTest {
     importService.importRankings(fixture("Herren_20180401.csv"));
 
     assertThrows(
-        ImportService.DuplicateImportError.class,
+        DuplicateImportError.class,
         () -> importService.importRankings(fixture("Herren_20180401.csv")));
   }
 

--- a/src/test/java/de/hdawg/rankinginfo/service/PlayerServiceTest.java
+++ b/src/test/java/de/hdawg/rankinginfo/service/PlayerServiceTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 
 import org.junit.jupiter.api.AfterEach;
@@ -24,21 +23,18 @@ class PlayerServiceTest {
 
   @Autowired RankingRepository rankingRepository;
 
-  private static final LocalDateTime NOW = LocalDateTime.of(2026, 1, 1, 0, 0);
-
   private final int maleId = 10_001_001;
   private final int femaleId = 20_001_001;
 
   @BeforeEach
   void seed() {
-    var now = NOW;
     var q = LocalDate.of(2026, 4, 1);
     var prevQ = LocalDate.of(2026, 1, 1);
     rankingRepository.saveAll(
         List.of(
-            r(maleId, "Mueller", "Hans", "m00", q, 1, now),
-            r(femaleId, "Meyer", "Anna", "w00", q, 1, now),
-            r(maleId, "Mueller", "Hans", "m00", prevQ, 2, now)));
+            r(maleId, "Mueller", "Hans", "m00", q, 1),
+            r(femaleId, "Meyer", "Anna", "w00", q, 1),
+            r(maleId, "Mueller", "Hans", "m00", prevQ, 2)));
   }
 
   @AfterEach
@@ -125,10 +121,9 @@ class PlayerServiceTest {
       String firstname,
       String ageGroup,
       LocalDate date,
-      int pos,
-      LocalDateTime now) {
+      int pos) {
     return new Ranking(
         0L, dtbId, lastname, firstname, "GER", ageGroup, date, pos, "100",
-        "TC Test", "TST", false, false, false, now, now);
+        "TC Test", "TST", false, false, false);
   }
 }

--- a/src/test/java/de/hdawg/rankinginfo/service/RankingServiceFilterTest.java
+++ b/src/test/java/de/hdawg/rankinginfo/service/RankingServiceFilterTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 
 import org.junit.jupiter.api.AfterEach;
@@ -24,23 +23,20 @@ class RankingServiceFilterTest {
 
   @Autowired RankingRepository rankingRepository;
 
-  private static final LocalDateTime NOW = LocalDateTime.of(2026, 1, 1, 0, 0);
-
   private final LocalDate q = LocalDate.of(2026, 4, 1);
   private final LocalDate pq = LocalDate.of(2026, 1, 1);
 
   @BeforeEach
   void seed() {
-    var now = NOW;
     rankingRepository.saveAll(
         List.of(
-            r(10_001_001, "m00", q, 1, "500", false, false, "TC Baden", "BAD", now),
-            r(10_002_002, "m00", q, 2, "490", false, false, "TC Other", "WTB", now),
-            r(10_001_001, "m00", pq, 3, "460", false, false, "TC Baden", "BAD", now),
-            r(20_001_001, "w00", q, 1, "500", false, false, "TC Baden", "BAD", now),
-            r(10_711_111, "U14", q, 1, "100", true, false, "TC Baden", "BAD", now),
-            r(10_711_112, "U13", q, 1, "90", false, true, "TC Baden", "BAD", now),
-            r(10_001_001, "m00", LocalDate.of(2026, 1, 1), 1, "500", false, false, "TC Baden", "BAD", now, true)));
+            r(10_001_001, "m00", q, 1, "500", false, false, "TC Baden", "BAD"),
+            r(10_002_002, "m00", q, 2, "490", false, false, "TC Other", "WTB"),
+            r(10_001_001, "m00", pq, 3, "460", false, false, "TC Baden", "BAD"),
+            r(20_001_001, "w00", q, 1, "500", false, false, "TC Baden", "BAD"),
+            r(10_711_111, "U14", q, 1, "100", true, false, "TC Baden", "BAD"),
+            r(10_711_112, "U13", q, 1, "90", false, true, "TC Baden", "BAD"),
+            r(10_001_001, "m00", LocalDate.of(2026, 1, 1), 1, "500", false, false, "TC Baden", "BAD", true)));
   }
 
   @AfterEach
@@ -170,7 +166,20 @@ class RankingServiceFilterTest {
       String score,
       boolean ageGroupRanking,
       boolean yobRanking) {
-    return r(dtbId, ageGroup, date, pos, score, ageGroupRanking, yobRanking, "TC Test", "TST", NOW, false);
+    return r(dtbId, ageGroup, date, pos, score, ageGroupRanking, yobRanking, "TC Test", "TST", false);
+  }
+
+  private Ranking r(
+      int dtbId,
+      String ageGroup,
+      LocalDate date,
+      int pos,
+      String score,
+      boolean ageGroupRanking,
+      boolean yobRanking,
+      String club,
+      String federation) {
+    return r(dtbId, ageGroup, date, pos, score, ageGroupRanking, yobRanking, club, federation, false);
   }
 
   private Ranking r(
@@ -183,24 +192,9 @@ class RankingServiceFilterTest {
       boolean yobRanking,
       String club,
       String federation,
-      LocalDateTime now) {
-    return r(dtbId, ageGroup, date, pos, score, ageGroupRanking, yobRanking, club, federation, now, false);
-  }
-
-  private Ranking r(
-      int dtbId,
-      String ageGroup,
-      LocalDate date,
-      int pos,
-      String score,
-      boolean ageGroupRanking,
-      boolean yobRanking,
-      String club,
-      String federation,
-      LocalDateTime now,
       boolean yearEndRanking) {
     return new Ranking(
         0L, dtbId, "Test", "Test", "GER", ageGroup, date, pos, score,
-        club, federation, ageGroupRanking, yobRanking, yearEndRanking, now, now);
+        club, federation, ageGroupRanking, yobRanking, yearEndRanking);
   }
 }

--- a/src/test/java/de/hdawg/rankinginfo/service/RankingServiceSlugTest.java
+++ b/src/test/java/de/hdawg/rankinginfo/service/RankingServiceSlugTest.java
@@ -1,0 +1,53 @@
+package de.hdawg.rankinginfo.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class RankingServiceSlugTest {
+
+  @Test
+  @DisplayName("Herren maps to m00")
+  void herrenToM00() {
+    assertEquals("m00", RankingService.toAgeGroupSlug("Herren", null));
+  }
+
+  @Test
+  @DisplayName("Damen maps to w00")
+  void damenToW00() {
+    assertEquals("w00", RankingService.toAgeGroupSlug("Damen", null));
+  }
+
+  @Test
+  @DisplayName("Junioren with age group maps to m-prefix slug")
+  void juniorenWithAgeGroup() {
+    assertEquals("mu14", RankingService.toAgeGroupSlug("Junioren", "U14"));
+  }
+
+  @Test
+  @DisplayName("Junioren without age group maps to overall")
+  void juniorenWithoutAgeGroup() {
+    assertEquals("overall", RankingService.toAgeGroupSlug("Junioren", null));
+    assertEquals("overall", RankingService.toAgeGroupSlug("Junioren", ""));
+  }
+
+  @Test
+  @DisplayName("Juniorinnen with age group maps to w-prefix slug")
+  void juniorinnenWithAgeGroup() {
+    assertEquals("wu12", RankingService.toAgeGroupSlug("Juniorinnen", "U12"));
+  }
+
+  @Test
+  @DisplayName("Juniorinnen without age group maps to overall")
+  void juniorinnenWithoutAgeGroup() {
+    assertEquals("overall", RankingService.toAgeGroupSlug("Juniorinnen", null));
+    assertEquals("overall", RankingService.toAgeGroupSlug("Juniorinnen", ""));
+  }
+
+  @Test
+  @DisplayName("unknown gender maps to overall")
+  void unknownGenderToOverall() {
+    assertEquals("overall", RankingService.toAgeGroupSlug("Unknown", null));
+  }
+}

--- a/src/test/java/de/hdawg/rankinginfo/web/ClubServiceTest.java
+++ b/src/test/java/de/hdawg/rankinginfo/web/ClubServiceTest.java
@@ -1,0 +1,62 @@
+package de.hdawg.rankinginfo.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class ClubServiceTest extends WebControllerTestBase {
+
+  @Autowired
+  private ClubService clubService;
+
+  @Test
+  @DisplayName("searchClubs returns combined youth and adult counts per club name")
+  void searchClubsReturnsCombinedCounts() {
+    var results = clubService.searchClubs("Baden");
+    assertFalse(results.isEmpty());
+    var club = results.get(0);
+    assertTrue(club.youthCount() >= 0);
+    assertTrue(club.adultCount() >= 0);
+  }
+
+  @Test
+  @DisplayName("searchClubs with no match returns empty list")
+  void searchClubsNoMatch() {
+    var results = clubService.searchClubs("XYZNOTEXIST");
+    assertTrue(results.isEmpty());
+  }
+
+  @Test
+  @DisplayName("getClubDetail groups players into age-group buckets")
+  void getClubDetailGroupsByAgeGroup() {
+    var detail = clubService.getClubDetail("TC Baden-Baden");
+    for (var entry : detail.entrySet()) {
+      assertFalse(entry.getValue().isEmpty(), "Each age group bucket should have at least one player");
+    }
+  }
+
+  @Test
+  @DisplayName("getClubDetail for unknown club returns empty map")
+  void getClubDetailUnknownClub() {
+    var detail = clubService.getClubDetail("XYZNOTEXIST");
+    assertTrue(detail.isEmpty());
+  }
+
+  @Test
+  @DisplayName("searchClubs result has correct field types")
+  void searchClubsHasCorrectFieldTypes() {
+    var results = clubService.searchClubs("Baden");
+    if (!results.isEmpty()) {
+      var club = results.get(0);
+      assertEquals(club.name().getClass(), String.class);
+      assertTrue(club.youthCount() >= 0);
+      assertTrue(club.adultCount() >= 0);
+    }
+  }
+}

--- a/src/test/java/de/hdawg/rankinginfo/web/FederationServiceTest.java
+++ b/src/test/java/de/hdawg/rankinginfo/web/FederationServiceTest.java
@@ -1,0 +1,46 @@
+package de.hdawg.rankinginfo.web;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class FederationServiceTest extends WebControllerTestBase {
+
+  @Autowired
+  private FederationService federationService;
+
+  @Test
+  @DisplayName("buildFederationData returns correctly keyed outer map")
+  void buildFederationDataReturnsCorrectKeys() {
+    var data = federationService.buildFederationData();
+    assertFalse(data.isEmpty());
+    data.forEach((fedName, agCounts) -> {
+      assertFalse(fedName.isBlank(), "Federation name should not be blank");
+      assertFalse(agCounts.isEmpty(), "Each federation should have at least one age group count");
+    });
+  }
+
+  @Test
+  @DisplayName("buildFederationData maps federation codes to display names")
+  void buildFederationDataMapsFederationCodes() {
+    var data = federationService.buildFederationData();
+    if (!data.isEmpty()) {
+      // Should contain full names, not raw codes
+      data.keySet().forEach(name ->
+          assertFalse(name.matches("[A-Z]{2,4}"), "Expected display name, not raw code: " + name));
+    }
+  }
+
+  @Test
+  @DisplayName("buildFederationData returns empty map when no data exists")
+  void buildFederationDataEmptyWhenNoData() {
+    // With base test data present, this verifies the result is non-null
+    var data = federationService.buildFederationData();
+    assertTrue(data != null);
+  }
+}

--- a/src/test/java/de/hdawg/rankinginfo/web/PlayerProfileServiceTest.java
+++ b/src/test/java/de/hdawg/rankinginfo/web/PlayerProfileServiceTest.java
@@ -1,0 +1,197 @@
+package de.hdawg.rankinginfo.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import de.hdawg.rankinginfo.domain.Ranking;
+import de.hdawg.rankinginfo.service.PlayerService;
+import de.hdawg.rankinginfo.web.viewmodel.CompleteRankingRow;
+
+class PlayerProfileServiceTest {
+
+  private final PlayerProfileService service = new PlayerProfileService();
+
+  private static Ranking r(int dtbId, String ageGroup, LocalDate date, int pos, String score) {
+    var now = LocalDateTime.now();
+    return new Ranking(0L, dtbId, "Test", "Player", "GER", ageGroup, date, pos, score, "TC Test", "HH",
+        false, false, false, now, now);
+  }
+
+  // --- buildCurrentRankings ---
+
+  @Test
+  @DisplayName("buildCurrentRankings returns empty list when currentQuarter is null")
+  void buildCurrentRankingsNullQuarter() {
+    var result = service.buildCurrentRankings(List.of(r(1, "m00", LocalDate.of(2024, 4, 1), 5, "800")), null, null);
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  @DisplayName("buildCurrentRankings with single quarter has null position/score change")
+  void buildCurrentRankingsSingleQuarter() {
+    var quarter = LocalDate.of(2024, 4, 1);
+    var rankings = List.of(r(1, "m00", quarter, 5, "800"));
+    var result = service.buildCurrentRankings(rankings, quarter, null);
+    assertEquals(1, result.size());
+    assertEquals("m00", result.get(0).ageGroup());
+    assertEquals(5, result.get(0).position());
+    assertNull(result.get(0).positionChange());
+    assertNull(result.get(0).scoreChange());
+  }
+
+  @Test
+  @DisplayName("buildCurrentRankings with two quarters computes position improvement")
+  void buildCurrentRankingsTwoQuarters() {
+    var prev = LocalDate.of(2024, 1, 1);
+    var curr = LocalDate.of(2024, 4, 1);
+    var rankings = List.of(
+        r(1, "m00", curr, 3, "820"),
+        r(1, "m00", prev, 5, "800"));
+    var result = service.buildCurrentRankings(rankings, curr, prev);
+    assertEquals(1, result.size());
+    assertEquals("+2", result.get(0).positionChange());
+  }
+
+  @Test
+  @DisplayName("buildCurrentRankings excludes overall age group")
+  void buildCurrentRankingsExcludesOverall() {
+    var quarter = LocalDate.of(2024, 4, 1);
+    var rankings = List.of(
+        r(1, "overall", quarter, 1, "850"),
+        r(1, "m00", quarter, 5, "800"));
+    var result = service.buildCurrentRankings(rankings, quarter, null);
+    assertEquals(1, result.size());
+    assertEquals("m00", result.get(0).ageGroup());
+  }
+
+  // --- buildCompleteRankings ---
+
+  @Test
+  @DisplayName("buildCompleteRankings groups by date and maps quarter correctly")
+  void buildCompleteRankingsGrouping() {
+    var rankings = List.of(
+        r(1, "m00", LocalDate.of(2024, 4, 1), 5, "800"),
+        r(1, "m00", LocalDate.of(2024, 1, 1), 6, "780"));
+    var result = service.buildCompleteRankings(rankings);
+    assertEquals(2, result.size());
+    assertEquals("2024/Q2", result.get(0).date());
+    assertEquals("2024/Q1", result.get(1).date());
+  }
+
+  @Test
+  @DisplayName("buildCompleteRankings maps adult age groups to Aktive")
+  void buildCompleteRankingsMapsAdultToAktive() {
+    var rankings = List.of(r(1, "m00", LocalDate.of(2024, 4, 1), 5, "800"));
+    var result = service.buildCompleteRankings(rankings);
+    assertEquals(1, result.size());
+    assertTrue(result.get(0).ageGroupPositions().containsKey("Aktive"));
+  }
+
+  @Test
+  @DisplayName("buildCompleteRankings skips rows with no QUARTER_MAP entry (e.g. month 2)")
+  void buildCompleteRankingsSkipsUnknownMonth() {
+    var rankings = List.of(r(1, "m00", LocalDate.of(2024, 2, 1), 5, "800"));
+    var result = service.buildCompleteRankings(rankings);
+    assertTrue(result.isEmpty());
+  }
+
+  // --- buildAvailableData ---
+
+  @Test
+  @DisplayName("buildAvailableData buckets years and quarters correctly")
+  void buildAvailableData() {
+    var rows = List.of(
+        new CompleteRankingRow("2024/Q1", "800", Map.of()),
+        new CompleteRankingRow("2024/Q2", "820", Map.of()),
+        new CompleteRankingRow("2023/Q4", "750", Map.of()));
+    var result = service.buildAvailableData(rows);
+    assertEquals(2, result.size());
+    assertTrue(result.get(2024).contains("Q1"));
+    assertTrue(result.get(2024).contains("Q2"));
+    assertTrue(result.get(2023).contains("Q4"));
+  }
+
+  @Test
+  @DisplayName("buildAvailableData returns descending year order")
+  void buildAvailableDataDescendingOrder() {
+    var rows = List.of(
+        new CompleteRankingRow("2022/Q1", "750", Map.of()),
+        new CompleteRankingRow("2024/Q1", "800", Map.of()));
+    var result = service.buildAvailableData(rows);
+    var years = result.keySet().stream().toList();
+    assertEquals(2024, years.get(0));
+    assertEquals(2022, years.get(1));
+  }
+
+  // --- computeScoreChange (tested indirectly via buildCurrentRankings) ---
+
+  @Test
+  @DisplayName("score change is null when scores are equal")
+  void scoreChangeNullWhenEqual() {
+    var prev = LocalDate.of(2024, 1, 1);
+    var curr = LocalDate.of(2024, 4, 1);
+    var rankings = List.of(
+        r(1, "m00", curr, 5, "800"),
+        r(1, "m00", prev, 5, "800"));
+    var result = service.buildCurrentRankings(rankings, curr, prev);
+    assertNull(result.get(0).scoreChange());
+  }
+
+  @Test
+  @DisplayName("score change handles comma-decimal format")
+  void scoreChangeCommaDecimal() {
+    var prev = LocalDate.of(2024, 1, 1);
+    var curr = LocalDate.of(2024, 4, 1);
+    var rankings = List.of(
+        r(1, "m00", curr, 5, "66,9"),
+        r(1, "m00", prev, 5, "64,0"));
+    var result = service.buildCurrentRankings(rankings, curr, prev);
+    assertTrue(result.get(0).scoreChange().startsWith("+"));
+  }
+
+  // --- PlayerService helpers ---
+
+  @Test
+  @DisplayName("dtbIdRange from 7-digit prefix returns correct range")
+  void dtbIdRangeSevenDigit() {
+    var service = new PlayerService(null);
+    var range = service.dtbIdRange("1234567");
+    assertEquals(12345670, range[0]);
+    assertEquals(12345679, range[1]);
+  }
+
+  @Test
+  @DisplayName("dtbIdRange from 8-digit ID returns exact range")
+  void dtbIdRangeEightDigit() {
+    var service = new PlayerService(null);
+    var range = service.dtbIdRange("12345678");
+    assertEquals(12345678, range[0]);
+    assertEquals(12345678, range[1]);
+  }
+
+  @Test
+  @DisplayName("dtbIdRange handles non-numeric input gracefully")
+  void dtbIdRangeInvalid() {
+    var service = new PlayerService(null);
+    var range = service.dtbIdRange("ABC");
+    assertEquals(0, range[0]);
+  }
+
+  @Test
+  @DisplayName("yobToMaleMarker converts last two yob digits to male marker")
+  void yobToMaleMarker() {
+    var service = new PlayerService(null);
+    assertEquals(110, service.yobToMaleMarker("2010"));
+    assertEquals(100, service.yobToMaleMarker("2000"));
+    assertEquals(112, service.yobToMaleMarker("2012"));
+  }
+}

--- a/src/test/java/de/hdawg/rankinginfo/web/PlayerProfileServiceTest.java
+++ b/src/test/java/de/hdawg/rankinginfo/web/PlayerProfileServiceTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -21,9 +20,8 @@ class PlayerProfileServiceTest {
   private final PlayerProfileService service = new PlayerProfileService();
 
   private static Ranking r(int dtbId, String ageGroup, LocalDate date, int pos, String score) {
-    var now = LocalDateTime.now();
     return new Ranking(0L, dtbId, "Test", "Player", "GER", ageGroup, date, pos, score, "TC Test", "HH",
-        false, false, false, now, now);
+        false, false, false);
   }
 
   // --- buildCurrentRankings ---

--- a/src/test/java/de/hdawg/rankinginfo/web/WebControllerTestBase.java
+++ b/src/test/java/de/hdawg/rankinginfo/web/WebControllerTestBase.java
@@ -34,12 +34,12 @@ public abstract class WebControllerTestBase {
   protected void seed() {
     rankingRepository.saveAll(
         List.of(
-            r(10_001_001, "Mueller", "Hans", "m00", q, 1, "500", false, false, "TC Baden", "BAD", NOW),
-            r(10_002_002, "Schmidt", "Peter", "m00", q, 2, "490", false, false, "TC Other", "WTB", NOW),
-            r(10_001_001, "Mueller", "Hans", "m00", pq, 3, "460", false, false, "TC Baden", "BAD", NOW),
-            r(20_001_001, "Meyer", "Anna", "w00", q, 1, "500", false, false, "TC Baden", "BAD", NOW),
-            r(10_711_111, "Juniormann", "Max", "overall", q, 1, "100", false, false, "TC Baden", "BAD", NOW),
-            r(10_711_112, "Juniormann2", "Max", "U14", q, 1, "100", false, true, "TC Baden", "BAD", NOW)));
+            r(10_001_001, "Mueller", "Hans", "m00", q, 1, "500", false, false, "TC Baden", "BAD"),
+            r(10_002_002, "Schmidt", "Peter", "m00", q, 2, "490", false, false, "TC Other", "WTB"),
+            r(10_001_001, "Mueller", "Hans", "m00", pq, 3, "460", false, false, "TC Baden", "BAD"),
+            r(20_001_001, "Meyer", "Anna", "w00", q, 1, "500", false, false, "TC Baden", "BAD"),
+            r(10_711_111, "Juniormann", "Max", "overall", q, 1, "100", false, false, "TC Baden", "BAD"),
+            r(10_711_112, "Juniormann2", "Max", "U14", q, 1, "100", false, true, "TC Baden", "BAD")));
   }
 
   @AfterEach
@@ -58,9 +58,8 @@ public abstract class WebControllerTestBase {
       String score,
       boolean ageGroupRanking,
       boolean yobRanking) {
-    return r(
-        dtbId, lastname, firstname, ageGroup, date, pos, score,
-        ageGroupRanking, yobRanking, "TC Test", "TST", NOW);
+    return r(dtbId, lastname, firstname, ageGroup, date, pos, score,
+        ageGroupRanking, yobRanking, "TC Test", "TST");
   }
 
   protected Ranking r(
@@ -74,10 +73,9 @@ public abstract class WebControllerTestBase {
       boolean ageGroupRanking,
       boolean yobRanking,
       String club,
-      String federation,
-      LocalDateTime now) {
+      String federation) {
     return new Ranking(
         0L, dtbId, lastname, firstname, "GER", ageGroup, date, pos, score,
-        club, federation, ageGroupRanking, yobRanking, false, now, now);
+        club, federation, ageGroupRanking, yobRanking, false);
   }
 }


### PR DESCRIPTION
## Summary

- **OpenCSV integration:** Replaced the hand-rolled `splitCsvLine`/`stripQuotes` helpers in `ImportService` with OpenCSV 5.12.0 (was already in `pom.xml` but unused)
- **Service extraction:** Moved all view-building logic out of controllers into dedicated service classes (`PlayerProfileService`, `ClubService`, `FederationService`); moved `toAgeGroupSlug()` from `ListingController` to `RankingService`
- **Typed view-models:** Replaced untyped `LinkedHashMap<String, Object>` structures with proper records (`CurrentRankingRow`, `CompleteRankingRow`, `ClubSummary`, `PlayerSummaryRow`, `DiagramDataView`, `AgeGroupTimeSeries`, `ScoreTimeSeries`)
- **Global exception handlers:** Added `GlobalWebExceptionHandler` (redirect with flash message) and `GlobalApiExceptionHandler` (JSON error responses) covering the web and API layers respectively
- **Tests:** Added 6 new test classes covering all new service methods (159 tests total, all passing)

## Performance & architecture improvements

- **Rate-limit bucket map** (`RateLimitFilter`): Replaced `ConcurrentHashMap<String, Bucket>` (unbounded, no eviction) with a Caffeine cache (2h access-based expiry), eliminating the memory leak for inactive tokens/IPs
- **Thymeleaf cache** moved to per-profile config: disabled only in `dev` and `local` profiles; `prod` now benefits from the default cache
- **Batch INSERT** (`RankingRepository.saveAll`): Replaced N individual `save()` calls with a single `namedJdbc.batchUpdate()` — reduces import round-trips from O(n) to 1
- **SQL constant deduplication** (`RankingRepository`): Extracted `RANKINGS_WHERE` text block to eliminate the duplicated WHERE clause shared by count and data queries
- **`fetchAvailableQuarters`** (`RankingService`): Replaced stream-sort-re-collect pattern with `TreeMap(Comparator.reverseOrder())` — produces correctly ordered map in a single pass
- **Magic number removed** (`ImportService`): `period.getYear() - 11` → named constant `YOUNGEST_AGE_GROUP`; substring arithmetic `Integer.parseInt(String.valueOf(year - ageGroup).substring(2, 4))` → `(year - ageGroup) % 100`
- **`DuplicateImportError`** promoted from inner class to top-level `service/DuplicateImportError.java`
- **`ImportProperties`** extracted as `@ConfigurationProperties` record, replacing `@Value("${import.folder}")` field injection in `RankingImportScheduler`
- **Domain / persistence separation** (`Ranking` record): Removed `createdAt`/`updatedAt` from the domain record — these are persistence metadata and are now set exclusively in `RankingEntity.fromDomain()` and the batch INSERT; the domain layer is no longer aware of them

## SpotBugs fixes

- `EI_EXPOSE_REP` / `EI_EXPOSE_REP2` on view-model records: Added compact constructors using `Map.copyOf()` / `List.copyOf()` to enforce immutability
- `REC_CATCH_EXCEPTION` in `PlayerController.show()`: Narrowed `catch (Exception e)` to `catch (IndexOutOfBoundsException e)` — the actual exception thrown when no ranking is found
- `URF_UNREAD_FIELD` for `RankingEntity.createdAt` / `updatedAt`: Fields are written for DB INSERT and read by Spring Data JDBC via reflection — added exclusions to `spotbugs-exclude.xml`

## Test plan

- [x] `./mvnw test` — 159 tests, 0 failures
- [x] `./mvnw spotless:check pmd:check` — no violations
- [x] `./mvnw verify` (SpotBugs) — 0 findings after exclusions
- [x] All existing controller tests remain green (no behavioral changes)
- [x] New unit tests for `PlayerProfileService`, `ClubService`, `FederationService`, `RankingService.toAgeGroupSlug`, `ImportService` CSV parsing
- [x] Integration test for `GlobalApiExceptionHandler` (500 on invalid date, 200 on valid request)