### PR TITLE
feat: phase 1 optimizations — jte templates, ObjectMapper, virtual threads, caching

### DIFF
--- a/src/main/java/de/hdawg/rankinginfo/api/security/BearerTokenFilter.java
+++ b/src/main/java/de/hdawg/rankinginfo/api/security/BearerTokenFilter.java
@@ -9,9 +9,9 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.http.MediaType;
 import org.springframework.web.filter.OncePerRequestFilter;
+import tools.jackson.databind.ObjectMapper;
 
 public class BearerTokenFilter extends OncePerRequestFilter {
 

--- a/src/main/java/de/hdawg/rankinginfo/api/security/RateLimitFilter.java
+++ b/src/main/java/de/hdawg/rankinginfo/api/security/RateLimitFilter.java
@@ -9,7 +9,6 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import io.github.bucket4j.Bandwidth;
@@ -17,6 +16,7 @@ import io.github.bucket4j.Bucket;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.filter.OncePerRequestFilter;
+import tools.jackson.databind.ObjectMapper;
 
 public class RateLimitFilter extends OncePerRequestFilter {
 

--- a/src/main/java/de/hdawg/rankinginfo/config/SecurityConfig.java
+++ b/src/main/java/de/hdawg/rankinginfo/config/SecurityConfig.java
@@ -1,6 +1,5 @@
 package de.hdawg.rankinginfo.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,6 +9,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import tools.jackson.databind.ObjectMapper;
 
 import de.hdawg.rankinginfo.api.security.BearerTokenFilter;
 import de.hdawg.rankinginfo.api.security.RateLimitFilter;
@@ -18,11 +18,6 @@ import de.hdawg.rankinginfo.api.security.RateLimitFilter;
 @EnableWebSecurity
 @EnableConfigurationProperties({ApiProperties.class, ImportProperties.class})
 public class SecurityConfig {
-
-  @Bean
-  public ObjectMapper objectMapper() {
-    return new ObjectMapper();
-  }
 
   @Bean
   @Order(1)

--- a/src/main/java/de/hdawg/rankinginfo/service/ImportService.java
+++ b/src/main/java/de/hdawg/rankinginfo/service/ImportService.java
@@ -111,7 +111,10 @@ public class ImportService {
 
   @Transactional
   @CacheEvict(
-      cacheNames = {"available_quarters", "available_dates", "federations", "player_counts"},
+      cacheNames = {
+        "available_quarters", "available_dates", "federations", "player_counts",
+        "max_imported_at", "federation_stats"
+      },
       allEntries = true)
   public void importRankings(Path file) throws DuplicateImportError, IOException {
     var fileNamePart = file.getFileName();
@@ -144,14 +147,20 @@ public class ImportService {
   }
 
   @CacheEvict(
-      cacheNames = {"available_quarters", "available_dates", "federations", "player_counts"},
+      cacheNames = {
+        "available_quarters", "available_dates", "federations", "player_counts",
+        "max_imported_at", "federation_stats"
+      },
       allEntries = true)
   public void scanAndImport(String folderPath) {
     doScanAndImport(folderPath, null);
   }
 
   @CacheEvict(
-      cacheNames = {"available_quarters", "available_dates", "federations", "player_counts"},
+      cacheNames = {
+        "available_quarters", "available_dates", "federations", "player_counts",
+        "max_imported_at", "federation_stats"
+      },
       allEntries = true)
   public void scanAndImport(String folderPath, @Nullable String errorLogPath) {
     doScanAndImport(folderPath, errorLogPath);

--- a/src/main/java/de/hdawg/rankinginfo/service/RankingService.java
+++ b/src/main/java/de/hdawg/rankinginfo/service/RankingService.java
@@ -84,6 +84,7 @@ public class RankingService {
         .collect(Collectors.toMap(Ranking::dtbId, Ranking::rankingPosition));
   }
 
+  @Cacheable("max_imported_at")
   @Nullable
   public LocalDateTime maxImportedAt() {
     return importHistoryRepository.findMaxImportedAt();

--- a/src/main/java/de/hdawg/rankinginfo/web/FederationService.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/FederationService.java
@@ -3,6 +3,7 @@ package de.hdawg.rankinginfo.web;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -46,6 +47,7 @@ public class FederationService {
     this.rankingRepository = rankingRepository;
   }
 
+  @Cacheable("federation_stats")
   public Map<String, Map<String, Integer>> buildFederationData() {
     var quarter = rankingRepository.findDistinctDatesDesc().stream().findFirst().orElse(null);
     var federations = new LinkedHashMap<String, Map<String, Integer>>();

--- a/src/main/java/de/hdawg/rankinginfo/web/PlayerController.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/PlayerController.java
@@ -18,9 +18,6 @@ import tools.jackson.databind.ObjectMapper;
 import de.hdawg.rankinginfo.repository.RankingRepository;
 import de.hdawg.rankinginfo.service.PlayerService;
 
-import de.hdawg.rankinginfo.repository.RankingRepository;
-import de.hdawg.rankinginfo.service.PlayerService;
-
 @SuppressWarnings("PMD.AvoidLiteralsInIfCondition")
 @Controller
 @RequestMapping("/players")

--- a/src/main/java/de/hdawg/rankinginfo/web/PlayerController.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/PlayerController.java
@@ -1,11 +1,9 @@
 package de.hdawg.rankinginfo.web;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import de.hdawg.rankinginfo.repository.RankingRepository;
-import de.hdawg.rankinginfo.service.PlayerService;
-import jakarta.servlet.http.HttpServletResponse;
 import java.util.Set;
+
+import jakarta.servlet.http.HttpServletResponse;
+
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -14,6 +12,11 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+
+import de.hdawg.rankinginfo.repository.RankingRepository;
+import de.hdawg.rankinginfo.service.PlayerService;
 
 @SuppressWarnings("PMD.AvoidLiteralsInIfCondition")
 @Controller
@@ -91,7 +94,7 @@ public class PlayerController {
   private String toJson(Object value) {
     try {
       return objectMapper.writeValueAsString(value);
-    } catch (JsonProcessingException _) {
+    } catch (JacksonException _) {
       return "[]";
     }
   }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -8,11 +8,9 @@ spring:
       maximum-pool-size: 5
       minimum-idle: 2
 
-server:
-  tomcat:
-    threads:
-      max: 25
-      min-spare: 5
+# Tomcat thread pool tuning removed: virtual threads (spring.threads.virtual.enabled)
+# handle concurrency without a fixed platform-thread pool.
+# HikariCP pool-size (maximum-pool-size: 5) remains the effective concurrency limiter.
 
 gg:
   jte:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,6 +12,9 @@ spring:
   security:
     user:
       password: disabled
+  threads:
+    virtual:
+      enabled: true
 
 server:
   port: 8080

--- a/src/test/java/de/hdawg/rankinginfo/api/PlayersApiControllerTest.java
+++ b/src/test/java/de/hdawg/rankinginfo/api/PlayersApiControllerTest.java
@@ -188,6 +188,15 @@ class PlayersApiControllerTest {
   }
 
   @Test
+  @DisplayName("show serializes ranking quarter as ISO-8601 string")
+  void showSerializesRankingQuarterAsIso8601String() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/players/10001001").header("Authorization", auth))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.rankings[0].quarter").value("2026-04-01"));
+  }
+
+  @Test
   @DisplayName("show returns multiple ranking entries across quarters")
   void showReturnsMultipleRankingEntriesAcrossQuarters() throws Exception {
     mockMvc

--- a/src/test/java/de/hdawg/rankinginfo/api/security/BearerTokenFilterTest.java
+++ b/src/test/java/de/hdawg/rankinginfo/api/security/BearerTokenFilterTest.java
@@ -9,13 +9,13 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletResponse;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import tools.jackson.databind.ObjectMapper;
 
 class BearerTokenFilterTest {
 


### PR DESCRIPTION
## Summary

- Replace Thymeleaf with jte (Java Template Engine) for all web templates — templates are hot-reloaded in dev mode and precompiled into the JAR for production
- Configure shared `ObjectMapper` bean to replace per-class instances
- Enable virtual threads for improved concurrency under load
- Add Caffeine caching (1h TTL) for `available_quarters`, `available_dates`, `federations`, `player_counts`, and `federation_stats`

## Test plan

- [x] All existing tests pass (`./mvnw test`)
- [x] Lint checks pass (`./mvnw spotless:check pmd:check`)
- [x] Web UI renders correctly for listing, player, club, federation, and static pages
- [x] HTMX partial rendering works for filtered listing results
- [x] Import clears all caches on completion