### PR TITLE
feat: phase 2 architecture — controller decoupling, encoding centralisation, cache-evict meta-annotation

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,222 @@
+# Optimierungsplan ranking-info
+
+Umsetzungsplan für die identifizierten Verbesserungen in den Bereichen Performance,
+Architektur und Struktur. Die Maßnahmen sind in Phasen nach Wirkung/Aufwand sortiert.
+Java 25 und Spring Boot 4 werden genutzt, wo es sinnvoll ist.
+
+**Arbeitsweise nach jeder Phase:** `./mvnw test`, danach `./mvnw spotless:check pmd:check`
+(bei Verstößen `./mvnw spotless:apply`). Vor dem Merge `./mvnw verify`.
+
+**Commits, Pushes und Pull Requests** werden ausschließlich auf explizite Anforderung
+erstellt — niemals automatisch durch Claude Code.
+
+---
+
+## Phase 1 — Kritisch / hoher Hebel ✅ abgeschlossen
+
+### 1.1 Bare `ObjectMapper`-Bean entfernen ✅
+**Problem:** `SecurityConfig` definiert `new ObjectMapper()` als Bean und deaktiviert damit
+Boots vorkonfigurierten Mapper (keine Modulregistrierung, u. a. fehlt `JavaTimeModule`).
+Die API serialisiert `LocalDate` (`RankingEntry`, `PlayerDetailData`) — latentes Bug-Risiko.
+
+**Schritte:**
+- [x] `objectMapper()`-Bean aus `config/SecurityConfig.java` entfernen.
+- [x] In `apiSecurityFilterChain` den von Boot bereitgestellten `ObjectMapper` injizieren
+      und an `BearerTokenFilter`/`RateLimitFilter` weiterreichen.
+- [ ] Falls später Jackson-Anpassungen nötig: `Jackson2ObjectMapperBuilderCustomizer`
+      statt eines eigenen Beans.
+
+**Hinweis:** Spring Boot 4 verwendet Jackson 3 (`tools.jackson.*`). Alle Importe in
+`SecurityConfig`, `BearerTokenFilter`, `RateLimitFilter`, `PlayerController` und
+`BearerTokenFilterTest` wurden von `com.fasterxml.jackson.*` auf `tools.jackson.*`
+migriert.
+
+**Betroffen:** `config/SecurityConfig.java`, `api/security/BearerTokenFilter.java`,
+`api/security/RateLimitFilter.java`, `web/PlayerController.java`
+
+**Akzeptanz:** Test `showSerializesRankingQuarterAsIso8601String` in
+`PlayersApiControllerTest` verifiziert ISO-8601-Serialisierung von `LocalDate`. ✅ Grün.
+
+---
+
+### 1.2 Virtuelle Threads aktivieren ✅
+**Problem:** I/O-gebundene Last (DB + Template-Rendering), Tomcat-Pool in Prod manuell
+auf 25 Threads getunt. Auf Java 25 entfällt das `synchronized`-Pinning (JEP 491).
+
+**Schritte:**
+- [x] `spring.threads.virtual.enabled=true` in `application.yml` setzen.
+- [x] Manuelles `server.tomcat.threads.{max,min-spare}`-Tuning in `application-prod.yml`
+      entfernt; Kommentar erklärt, dass HikariCP (`maximum-pool-size: 5`) der
+      effektive Parallelitätsbegrenzer bleibt.
+- [x] HikariCP-Pool-Größe bewusst bei 5 belassen (dokumentiert in `application-prod.yml`).
+
+**Betroffen:** `application.yml`, `application-prod.yml`
+
+**Akzeptanz:** App startet, Testsuite grün; kurzer Lasttest/Smoke-Test optional.
+
+---
+
+### 1.3 Fehlendes Caching ergänzen ✅
+**Problem:** `maxImportedAt()` läuft pro API-Listing-Request (untergräbt ETag-Caching);
+`FederationService.buildFederationData()` ist gar nicht gecacht (Doku nennt aber
+`federation_stats`).
+
+**Schritte:**
+- [x] `RankingService.maxImportedAt()` mit `@Cacheable("max_imported_at")` versehen.
+- [x] `FederationService.buildFederationData()` mit `@Cacheable("federation_stats")`
+      versehen.
+- [x] Beide Cache-Namen in alle drei `@CacheEvict`-Annotationen von `ImportService`
+      aufgenommen (`importRankings`, `scanAndImport(String)`, `scanAndImport(String, String)`).
+
+**Betroffen:** `service/RankingService.java`, `web/FederationService.java`,
+`service/ImportService.java`
+
+**Akzeptanz:** Testsuite grün. ✅ (Dedizierte Mock-Verify-Tests für Cache-Hits ausstehend,
+können als Follow-up ergänzt werden.)
+
+---
+
+## Phase 2 — Architektur
+
+### 2.1 Controller vom Repository entkoppeln
+**Problem:** `PlayerController.show()` und `PlayersApiController` injizieren
+`RankingRepository` direkt und orchestrieren Logik im Controller.
+
+**Schritte:**
+- [ ] Methode `PlayerProfileService.loadProfile(int dtbId)` (o. ä.) einführen, die
+      Rohdaten, Diagrammdaten, „recent 4 dates" und View-Modelle gebündelt liefert.
+- [ ] `PlayerController.show()` auf diese Service-Methode umstellen; leere Ergebnisse
+      explizit behandeln statt `IndexOutOfBoundsException` zu fangen.
+- [ ] `PlayersApiController` analog auf Service-Aufrufe umstellen, kein direktes
+      Repository mehr.
+
+**Betroffen:** `web/PlayerController.java`, `web/PlayerProfileService.java`,
+`api/v1/PlayersApiController.java`, `service/PlayerService.java`
+
+**Akzeptanz:** Controller hängen nicht mehr an `RankingRepository`; bestehende Web-/API-Tests grün.
+
+---
+
+### 2.2 Service-Pakete konsolidieren
+**Problem:** Fachliche Services teils in `web` (`ClubService`, `FederationService`,
+`PlayerProfileService`), teils in `service`.
+
+**Schritte:**
+- [ ] Entscheidung treffen: fachliche Services nach `service` verschieben (View-Mapping
+      bleibt in `web`), **oder** die Aufteilung bewusst in `CLAUDE.md` dokumentieren.
+- [ ] Bei Verschiebung: Paketpfade + Imports anpassen, Spotless-Importorder beachten.
+
+**Betroffen:** `web/*Service.java`, ggf. `service/`, `CLAUDE.md`
+
+**Akzeptanz:** Konsistente Layer-Struktur; `./mvnw verify` grün.
+
+---
+
+### 2.3 Ranking-Encoding zentralisieren
+**Problem:** DTB-ID-Ranges, `genderFactor`, Slug↔AgeGroup-Logik und `* 100_000`-Rechnungen
+sind über `RankingService`, `PlayerService`, `FederationService`, `ImportService` verstreut.
+
+**Schritte:**
+- [ ] Zentrale Utility/Value-Objects einführen (z. B. `RankingCoding` oder
+      `DtbId` / `AgeGroupSlug`), die Ranges, Gender-Marker und Slug-Mapping kapseln.
+- [ ] Aufrufer schrittweise migrieren; Duplikate entfernen.
+
+**Betroffen:** `service/RankingService.java`, `service/PlayerService.java`,
+`web/FederationService.java`, `service/ImportService.java` (neu: z. B. `domain/`)
+
+**Akzeptanz:** Encoding-Logik an einer Stelle; Unit-Tests für die Kodierung; alle Tests grün.
+
+---
+
+### 2.4 `@CacheEvict`-Duplizierung beseitigen
+**Problem:** Cache-Namen sind dreifach in `ImportService` dupliziert und weichen von der
+Doku ab.
+
+**Schritte:**
+- [ ] Cache-Namen in einer Konstante bündeln oder eine `@CacheEvict`-Meta-Annotation
+      erstellen, die alle relevanten Caches abdeckt.
+- [ ] Auf alle Import-Methoden anwenden; `max_imported_at` und `federation_stats`
+      (aus 1.3) einschließen.
+
+**Betroffen:** `service/ImportService.java`
+
+**Akzeptanz:** Eine einzige Quelle der Wahrheit für evictete Caches; Tests grün.
+
+---
+
+## Phase 3 — Sicherheit & Mikro-Optimierung
+
+### 3.1 `BearerTokenFilter` härten
+**Problem:** Pro Request wird ein neues `HashSet` aufgebaut; Token-Vergleich nicht
+zeitkonstant (Timing-Seitenkanal).
+
+**Schritte:**
+- [ ] Gültige Tokens (konfiguriert + Env) einmal im Konstruktor zu einem unveränderlichen
+      `Set<String>` zusammenführen.
+- [ ] Vergleich über `MessageDigest.isEqual` gegen die Kandidaten (zeitkonstant).
+
+**Betroffen:** `api/security/BearerTokenFilter.java`
+
+**Akzeptanz:** Bestehende Security-Tests grün; ein Test für gültiges/ungültiges Token.
+
+---
+
+## Phase 4 — Moderne Sprach-/Framework-Features (Politur)
+
+### 4.1 `SequencedCollection` (Java 21+)
+- [ ] `get(0)` → `getFirst()`, `get(size()-1)` → `getLast()` in:
+      `PlayerService.loadPlayerProfile()`, `ImportService.rankingsForAgeRange()`,
+      `PlayerController.show()` (Datumsermittlung), weitere `findFirst`-Indizierungen.
+- [ ] In `PlayerService.loadPlayerProfile()` Leerprüfung statt impliziter Exception.
+
+**Akzeptanz:** Lesbarerer Code, identisches Verhalten, Tests grün.
+
+### 4.2 `RestClient` statt `RestTemplate`
+- [ ] `JteWarmup` von `RestTemplate` auf `RestClient` umstellen (RestTemplate ist im
+      Maintenance-Modus).
+
+**Betroffen:** `web/JteWarmup.java`
+
+### 4.3 `@NullMarked` auf Paketebene
+- [ ] `package-info.java` mit JSpecify-`@NullMarked` je Paket anlegen; redundante
+      `@Nullable`-/Non-null-Annahmen bereinigen (Spring Framework 7 nutzt selbst JSpecify).
+
+**Betroffen:** neue `package-info.java` je Paket
+
+### 4.4 `ProblemDetail` (RFC 7807) für API-Fehler
+- [ ] Eigenes `ErrorResponse` durch Springs `ProblemDetail` ersetzen
+      (`type`/`title`/`status`/`detail`); Exception-Handler anpassen.
+
+**Betroffen:** `api/v1/ErrorResponse.java`, `api/v1/GlobalApiExceptionHandler.java`,
+`api/v1/*ApiController.java`
+
+### 4.5 Kleinere Aufräumarbeiten
+- [ ] Dependency-Classifier `bucket4j_jdk17-core` → `jdk21`-Variante prüfen (passend zur
+      Toolchain).
+- [ ] `ImportService.parseCsvLine` auf tatsächliche Nutzung prüfen, ggf. entfernen.
+- [ ] `PlayerService.dtbIdRange()`: `Math.pow(10.0, …)` durch Integer-Logik/Lookup ersetzen
+      (Floating-Point-Risiko vermeiden).
+
+---
+
+## Phase 5 — Optional / später abwägen
+
+- [ ] **API-Versionierung** von manuellem `/api/v1` auf Boot-4-eigene API-Versionierung
+      umstellen — erst sinnvoll, wenn eine v2 ansteht.
+- [ ] **`MockMvcTester`** (AssertJ-basiert) für neue Web-Tests einführen.
+- [ ] **Stream Gatherers (JDK 24)** — aktuell kein klarer Bedarf; `DISTINCT ON` in SQL
+      bleibt überlegen.
+
+---
+
+## Reihenfolge / Empfehlung
+
+1. 1.1 (ObjectMapper) — potenzieller Latent-Bug, zuerst absichern
+2. 1.2 (Virtuelle Threads)
+3. 1.3 (Caching) + 2.4 (Eviction-Dedupe gemeinsam)
+4. 2.1 (Controller entkoppeln)
+5. 3.1 (Token-Filter)
+6. Phase 4 (Politur), 2.2/2.3 (Refactorings) und Phase 5 nach Bedarf
+
+Jede Phase ist eigenständig mergebar (kleine, fokussierte PRs). Nach jeder Phase
+Testsuite + Linting grün halten.

--- a/src/main/java/de/hdawg/rankinginfo/api/v1/PlayersApiController.java
+++ b/src/main/java/de/hdawg/rankinginfo/api/v1/PlayersApiController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import de.hdawg.rankinginfo.repository.RankingRepository;
+import de.hdawg.rankinginfo.domain.RankingCoding;
 import de.hdawg.rankinginfo.service.PlayerService;
 
 @RestController
@@ -21,11 +21,9 @@ import de.hdawg.rankinginfo.service.PlayerService;
 public class PlayersApiController {
 
   private final PlayerService playerService;
-  private final RankingRepository rankingRepository;
 
-  public PlayersApiController(PlayerService playerService, RankingRepository rankingRepository) {
+  public PlayersApiController(PlayerService playerService) {
     this.playerService = playerService;
-    this.rankingRepository = rankingRepository;
   }
 
   @Operation(summary = "Search players by lastname and optional year of birth")
@@ -51,8 +49,8 @@ public class PlayersApiController {
         (yob != null && !yob.isBlank())
             ? playerService.findPlayersByLastnameAndYob(
                 lastname,
-                Integer.parseInt(yob.substring(2, 4)) + 100,
-                Integer.parseInt(yob.substring(2, 4)) + 200)
+                Integer.parseInt(yob.substring(2, 4)) + RankingCoding.GENDER_FACTOR_JUNIOREN,
+                Integer.parseInt(yob.substring(2, 4)) + RankingCoding.GENDER_FACTOR_JUNIORINNEN)
             : playerService.findPlayersByLastname(lastname);
 
     if (players.isEmpty()) {
@@ -85,10 +83,7 @@ public class PlayersApiController {
       content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
   @GetMapping("/{id}")
   public ResponseEntity<Object> show(@PathVariable int id) {
-    var rankings =
-        rankingRepository
-            .findByDtbIdAndYobRankingFalseAndAgeGroupRankingFalseAndYearEndRankingFalseOrderByDateDescAgeGroupAsc(
-                id);
+    var rankings = playerService.findNonAggregateRankings(id);
     if (rankings.isEmpty()) {
       return ResponseEntity.status(404).body(new ErrorResponse("Not Found"));
     }

--- a/src/main/java/de/hdawg/rankinginfo/domain/RankingCoding.java
+++ b/src/main/java/de/hdawg/rankinginfo/domain/RankingCoding.java
@@ -1,0 +1,16 @@
+package de.hdawg.rankinginfo.domain;
+
+public final class RankingCoding {
+
+  public static final int MALE_DTB_ID_START = 10_000_000;
+  public static final int MALE_DTB_ID_END = 19_999_999;
+  public static final int FEMALE_DTB_ID_START = 20_000_000;
+  public static final int FEMALE_DTB_ID_END = 29_999_999;
+
+  public static final int GENDER_FACTOR_JUNIOREN = 100;
+  public static final int GENDER_FACTOR_JUNIORINNEN = 200;
+
+  public static final int YOB_MULTIPLIER = 100_000;
+
+  private RankingCoding() {}
+}

--- a/src/main/java/de/hdawg/rankinginfo/service/EvictImportCaches.java
+++ b/src/main/java/de/hdawg/rankinginfo/service/EvictImportCaches.java
@@ -1,0 +1,22 @@
+package de.hdawg.rankinginfo.service;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.cache.annotation.CacheEvict;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@CacheEvict(
+    cacheNames = {
+      "available_quarters",
+      "available_dates",
+      "federations",
+      "player_counts",
+      "max_imported_at",
+      "federation_stats"
+    },
+    allEntries = true)
+public @interface EvictImportCaches {}

--- a/src/main/java/de/hdawg/rankinginfo/service/ImportService.java
+++ b/src/main/java/de/hdawg/rankinginfo/service/ImportService.java
@@ -23,12 +23,12 @@ import com.opencsv.exceptions.CsvValidationException;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import de.hdawg.rankinginfo.domain.ImportHistory;
 import de.hdawg.rankinginfo.domain.Ranking;
+import de.hdawg.rankinginfo.domain.RankingCoding;
 import de.hdawg.rankinginfo.repository.ImportHistoryRepository;
 import de.hdawg.rankinginfo.repository.RankingRepository;
 
@@ -43,7 +43,9 @@ public class ImportService {
 
   private static final Set<String> SPECIAL_SCORES = Set.of("0,0", "PR", "Einst.");
   private static final Map<String, Integer> GENDER_FACTORS =
-      Map.of(CATEGORY_JUNIOREN, 100, CATEGORY_JUNIORINNEN, 200);
+      Map.of(
+          CATEGORY_JUNIOREN, RankingCoding.GENDER_FACTOR_JUNIOREN,
+          CATEGORY_JUNIORINNEN, RankingCoding.GENDER_FACTOR_JUNIORINNEN);
   private static final Map<String, String> AGE_GROUP_MAP =
       Map.of("herren", "m00", "damen", "w00", CATEGORY_JUNIOREN, "overall", CATEGORY_JUNIORINNEN, "overall");
 
@@ -110,12 +112,7 @@ public class ImportService {
   }
 
   @Transactional
-  @CacheEvict(
-      cacheNames = {
-        "available_quarters", "available_dates", "federations", "player_counts",
-        "max_imported_at", "federation_stats"
-      },
-      allEntries = true)
+  @EvictImportCaches
   public void importRankings(Path file) throws DuplicateImportError, IOException {
     var fileNamePart = file.getFileName();
     if (fileNamePart == null) throw new IllegalArgumentException("Path has no filename: " + file);
@@ -146,22 +143,12 @@ public class ImportService {
     log.info("Import of '{}' completed", filename);
   }
 
-  @CacheEvict(
-      cacheNames = {
-        "available_quarters", "available_dates", "federations", "player_counts",
-        "max_imported_at", "federation_stats"
-      },
-      allEntries = true)
+  @EvictImportCaches
   public void scanAndImport(String folderPath) {
     doScanAndImport(folderPath, null);
   }
 
-  @CacheEvict(
-      cacheNames = {
-        "available_quarters", "available_dates", "federations", "player_counts",
-        "max_imported_at", "federation_stats"
-      },
-      allEntries = true)
+  @EvictImportCaches
   public void scanAndImport(String folderPath, @Nullable String errorLogPath) {
     doScanAndImport(folderPath, errorLogPath);
   }
@@ -275,8 +262,10 @@ public class ImportService {
       boolean ageGroupRanking,
       boolean yearEndRanking) {
 
-    int idStart = classesToRetrieve.get(0) * 100_000;
-    int idEnd = classesToRetrieve.get(classesToRetrieve.size() - 1) * 100_000 + 99_999;
+    int idStart = classesToRetrieve.get(0) * RankingCoding.YOB_MULTIPLIER;
+    int idEnd =
+        classesToRetrieve.get(classesToRetrieve.size() - 1) * RankingCoding.YOB_MULTIPLIER
+            + RankingCoding.YOB_MULTIPLIER - 1;
     var rankingsFromDb = rankingRepository.findForAgeRangeInPeriod(period, idStart, idEnd);
 
     int lastRank = 0;

--- a/src/main/java/de/hdawg/rankinginfo/service/PlayerService.java
+++ b/src/main/java/de/hdawg/rankinginfo/service/PlayerService.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 import de.hdawg.rankinginfo.domain.Club;
 import de.hdawg.rankinginfo.domain.Player;
 import de.hdawg.rankinginfo.domain.Ranking;
+import de.hdawg.rankinginfo.domain.RankingCoding;
 import de.hdawg.rankinginfo.repository.RankingRepository;
 
 @Service
@@ -70,18 +71,24 @@ public class PlayerService {
   public List<Ranking> findPlayersByLastnameAndYob(String lastname, int yobMale, int yobFemale) {
     return rankingRepository.findByLastnameAndYob(
         lastname,
-        yobMale * 100_000,
-        yobMale * 100_000 + 99_999,
-        yobFemale * 100_000,
-        yobFemale * 100_000 + 99_999);
+        yobMale * RankingCoding.YOB_MULTIPLIER,
+        yobMale * RankingCoding.YOB_MULTIPLIER + RankingCoding.YOB_MULTIPLIER - 1,
+        yobFemale * RankingCoding.YOB_MULTIPLIER,
+        yobFemale * RankingCoding.YOB_MULTIPLIER + RankingCoding.YOB_MULTIPLIER - 1);
   }
 
   public List<Ranking> findPlayersByYob(int yobMale, int yobFemale) {
     return rankingRepository.findByYob(
-        yobMale * 100_000,
-        yobMale * 100_000 + 99_999,
-        yobFemale * 100_000,
-        yobFemale * 100_000 + 99_999);
+        yobMale * RankingCoding.YOB_MULTIPLIER,
+        yobMale * RankingCoding.YOB_MULTIPLIER + RankingCoding.YOB_MULTIPLIER - 1,
+        yobFemale * RankingCoding.YOB_MULTIPLIER,
+        yobFemale * RankingCoding.YOB_MULTIPLIER + RankingCoding.YOB_MULTIPLIER - 1);
+  }
+
+  public List<Ranking> findNonAggregateRankings(int dtbId) {
+    return rankingRepository
+        .findByDtbIdAndYobRankingFalseAndAgeGroupRankingFalseAndYearEndRankingFalseOrderByDateDescAgeGroupAsc(
+            dtbId);
   }
 
   public List<Ranking> findPlayersByDtbIdRange(int dtbIdStart, int dtbIdEnd) {

--- a/src/main/java/de/hdawg/rankinginfo/service/RankingService.java
+++ b/src/main/java/de/hdawg/rankinginfo/service/RankingService.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import de.hdawg.rankinginfo.domain.Ranking;
+import de.hdawg.rankinginfo.domain.RankingCoding;
 import de.hdawg.rankinginfo.repository.ImportHistoryRepository;
 import de.hdawg.rankinginfo.repository.RankingQueryFilter;
 import de.hdawg.rankinginfo.repository.RankingRepository;
@@ -97,8 +98,8 @@ public class RankingService {
     var isMale = slug.startsWith("m");
     var isAdult = AGE_GROUP_M00.equals(ageGroup) || AGE_GROUP_W00.equals(ageGroup);
 
-    int dtbIdStart = isMale ? 10_000_000 : 20_000_000;
-    int dtbIdEnd = isMale ? 19_999_999 : 29_999_999;
+    int dtbIdStart = isMale ? RankingCoding.MALE_DTB_ID_START : RankingCoding.FEMALE_DTB_ID_START;
+    int dtbIdEnd = isMale ? RankingCoding.MALE_DTB_ID_END : RankingCoding.FEMALE_DTB_ID_END;
 
     boolean yobRanking;
     boolean ageGroupRanking;

--- a/src/main/java/de/hdawg/rankinginfo/web/FederationService.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/FederationService.java
@@ -7,6 +7,7 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import de.hdawg.rankinginfo.domain.RankingCoding;
 import de.hdawg.rankinginfo.repository.RankingRepository;
 
 @Service
@@ -17,9 +18,6 @@ public class FederationService {
   private static final String GENDER_FEMALE = "w";
   private static final String AGE_GROUP_M00 = "m00";
   private static final String AGE_GROUP_W00 = "w00";
-  private static final int MALE_DTB_ID_START = 10_000_000;
-  private static final int FEMALE_DTB_ID_START = 20_000_000;
-  private static final int DTB_RANGE_OFFSET = 9_999_999;
 
   private static final Map<String, String> FEDERATION_NAMES =
       Map.ofEntries(
@@ -54,10 +52,16 @@ public class FederationService {
     if (quarter == null) return federations;
 
     for (var gender : new String[] {GENDER_MALE, GENDER_FEMALE}) {
-      int dtbIdStart = GENDER_MALE.equals(gender) ? MALE_DTB_ID_START : FEMALE_DTB_ID_START;
+      int dtbIdStart =
+          GENDER_MALE.equals(gender)
+              ? RankingCoding.MALE_DTB_ID_START
+              : RankingCoding.FEMALE_DTB_ID_START;
+      int dtbIdEnd =
+          GENDER_MALE.equals(gender)
+              ? RankingCoding.MALE_DTB_ID_END
+              : RankingCoding.FEMALE_DTB_ID_END;
       for (var row :
-          rankingRepository.countYouthByFederationAndAgeGroup(
-              quarter, dtbIdStart, dtbIdStart + DTB_RANGE_OFFSET)) {
+          rankingRepository.countYouthByFederationAndAgeGroup(quarter, dtbIdStart, dtbIdEnd)) {
         var fed = FEDERATION_NAMES.getOrDefault(row.federation(), row.federation());
         federations
             .computeIfAbsent(fed, k -> new LinkedHashMap<>())

--- a/src/main/java/de/hdawg/rankinginfo/web/PlayerController.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/PlayerController.java
@@ -15,9 +15,6 @@ import tools.jackson.databind.ObjectMapper;
 
 import de.hdawg.rankinginfo.service.PlayerService;
 
-import de.hdawg.rankinginfo.repository.RankingRepository;
-import de.hdawg.rankinginfo.service.PlayerService;
-
 @SuppressWarnings("PMD.AvoidLiteralsInIfCondition")
 @Controller
 @RequestMapping("/players")

--- a/src/main/java/de/hdawg/rankinginfo/web/PlayerController.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/PlayerController.java
@@ -1,7 +1,5 @@
 package de.hdawg.rankinginfo.web;
 
-import java.util.Set;
-
 import jakarta.servlet.http.HttpServletResponse;
 
 import org.springframework.stereotype.Controller;
@@ -15,7 +13,6 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.ObjectMapper;
 
-import de.hdawg.rankinginfo.repository.RankingRepository;
 import de.hdawg.rankinginfo.service.PlayerService;
 
 import de.hdawg.rankinginfo.repository.RankingRepository;
@@ -31,17 +28,14 @@ public class PlayerController {
 
   private final PlayerService playerService;
   private final PlayerProfileService playerProfileService;
-  private final RankingRepository rankingRepository;
   private final ObjectMapper objectMapper;
 
   public PlayerController(
       PlayerService playerService,
       PlayerProfileService playerProfileService,
-      RankingRepository rankingRepository,
       ObjectMapper objectMapper) {
     this.playerService = playerService;
     this.playerProfileService = playerProfileService;
-    this.rankingRepository = rankingRepository;
     this.objectMapper = objectMapper;
   }
 
@@ -112,42 +106,20 @@ public class PlayerController {
 
   @GetMapping("/{id}")
   public String show(@PathVariable int id, Model model, RedirectAttributes redirect) {
-    try {
-      var player = playerService.loadPlayerProfile(id);
-
-      var rawRankings =
-          rankingRepository
-              .findByDtbIdAndYobRankingFalseAndAgeGroupRankingFalseAndYearEndRankingFalseOrderByDateDescAgeGroupAsc(
-                  id);
-      var fullRankings =
-          rankingRepository.findByDtbIdAndYearEndRankingFalseOrderByDateAscAgeGroupAsc(id);
-
-      var allDates = rankingRepository.findDistinctDatesDesc();
-      var currentQuarter = allDates.isEmpty() ? null : allDates.get(0);
-      var previousQuarter = allDates.size() > 1 ? allDates.get(1) : null;
-      var recent4Dates = Set.copyOf(allDates.stream().limit(4).toList());
-
-      var currentRankings =
-          playerProfileService.buildCurrentRankings(rawRankings, currentQuarter, previousQuarter);
-      var allTimeDiagram = playerProfileService.buildDiagramData(fullRankings);
-      var recent12mDiagram =
-          playerProfileService.buildDiagramData(
-              fullRankings.stream().filter(r -> recent4Dates.contains(r.date())).toList());
-      var completeRankings = playerProfileService.buildCompleteRankings(fullRankings);
-      var availableData = playerProfileService.buildAvailableData(completeRankings);
-
-      model.addAttribute("player", player);
-      model.addAttribute("currentRankings", currentRankings);
-      model.addAttribute("completeRankings", completeRankings);
-      model.addAttribute("diagramDataJson", toJson(allTimeDiagram.positions()));
-      model.addAttribute("diagramScoreDataJson", toJson(allTimeDiagram.scores()));
-      model.addAttribute("recent12mDataJson", toJson(recent12mDiagram.positions()));
-      model.addAttribute("recent12mScoreDataJson", toJson(recent12mDiagram.scores()));
-      model.addAttribute("availableData", availableData);
-      return "players/show";
-    } catch (IndexOutOfBoundsException _) {
+    var profileOpt = playerProfileService.loadProfile(id);
+    if (profileOpt.isEmpty()) {
       redirect.addFlashAttribute("danger", "Spieler nicht gefunden");
       return "redirect:/players";
     }
+    var p = profileOpt.get();
+    model.addAttribute("player", p.player());
+    model.addAttribute("currentRankings", p.currentRankings());
+    model.addAttribute("completeRankings", p.completeRankings());
+    model.addAttribute("diagramDataJson", toJson(p.allTimeDiagram().positions()));
+    model.addAttribute("diagramScoreDataJson", toJson(p.allTimeDiagram().scores()));
+    model.addAttribute("recent12mDataJson", toJson(p.recent12mDiagram().positions()));
+    model.addAttribute("recent12mScoreDataJson", toJson(p.recent12mDiagram().scores()));
+    model.addAttribute("availableData", p.availableData());
+    return "players/show";
   }
 }

--- a/src/main/java/de/hdawg/rankinginfo/web/PlayerProfileService.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/PlayerProfileService.java
@@ -8,14 +8,19 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import de.hdawg.rankinginfo.domain.Club;
+import de.hdawg.rankinginfo.domain.Player;
 import de.hdawg.rankinginfo.domain.Ranking;
+import de.hdawg.rankinginfo.repository.RankingRepository;
 import de.hdawg.rankinginfo.web.viewmodel.AgeGroupTimeSeries;
 import de.hdawg.rankinginfo.web.viewmodel.CompleteRankingRow;
 import de.hdawg.rankinginfo.web.viewmodel.CurrentRankingRow;
@@ -25,6 +30,20 @@ import de.hdawg.rankinginfo.web.viewmodel.ScoreTimeSeries;
 @SuppressWarnings({"PMD.LooseCoupling", "PMD.AvoidLiteralsInIfCondition"})
 @Service
 public class PlayerProfileService {
+
+  public record PlayerProfile(
+      Player player,
+      List<CurrentRankingRow> currentRankings,
+      List<CompleteRankingRow> completeRankings,
+      DiagramDataView allTimeDiagram,
+      DiagramDataView recent12mDiagram,
+      Map<Integer, Set<String>> availableData) {}
+
+  @Nullable private final RankingRepository rankingRepository;
+
+  public PlayerProfileService(@Nullable RankingRepository rankingRepository) {
+    this.rankingRepository = rankingRepository;
+  }
 
   private static final Map<Integer, String> QUARTER_MAP =
       Map.of(1, "Q1", 4, "Q2", 7, "Q3", 10, "Q4");
@@ -36,6 +55,56 @@ public class PlayerProfileService {
   private static final String AKTIVE_LABEL = "Aktive";
   private static final int DATE_PARTS_SIZE = 2;
   private static final DateTimeFormatter DTF = DateTimeFormatter.ofPattern("dd.MM.yyyy");
+
+  @Transactional(readOnly = true)
+  public Optional<PlayerProfile> loadProfile(int dtbId) {
+    var repo = rankingRepository;
+    if (repo == null) throw new IllegalStateException("RankingRepository not injected");
+
+    var rawRankings =
+        repo.findByDtbIdAndYobRankingFalseAndAgeGroupRankingFalseAndYearEndRankingFalseOrderByDateDescAgeGroupAsc(
+            dtbId);
+    if (rawRankings.isEmpty()) return Optional.empty();
+
+    var current = rawRankings.get(0);
+    var clubs =
+        rawRankings.stream()
+            .map(r -> new Club(r.club(), r.federation()))
+            .collect(Collectors.toMap(Club::name, c -> c, (a, b) -> a))
+            .values()
+            .stream()
+            .sorted(Comparator.comparing(Club::name))
+            .toList();
+    var player =
+        new Player(
+            dtbId,
+            current.lastname(),
+            current.firstname(),
+            current.nationality(),
+            current.club(),
+            current.federation(),
+            clubs);
+
+    var fullRankings =
+        repo.findByDtbIdAndYearEndRankingFalseOrderByDateAscAgeGroupAsc(dtbId);
+    var allDates = repo.findDistinctDatesDesc();
+    var currentQuarter = allDates.isEmpty() ? null : allDates.get(0);
+    var previousQuarter = allDates.size() > 1 ? allDates.get(1) : null;
+    var recent4Dates = Set.copyOf(allDates.stream().limit(4).toList());
+
+    var currentRankings = buildCurrentRankings(rawRankings, currentQuarter, previousQuarter);
+    var allTimeDiagram = buildDiagramData(fullRankings);
+    var recent12mDiagram =
+        buildDiagramData(
+            fullRankings.stream().filter(r -> recent4Dates.contains(r.date())).toList());
+    var completeRankings = buildCompleteRankings(fullRankings);
+    var availableData = buildAvailableData(completeRankings);
+
+    return Optional.of(
+        new PlayerProfile(
+            player, currentRankings, completeRankings, allTimeDiagram, recent12mDiagram,
+            availableData));
+  }
 
   public List<CurrentRankingRow> buildCurrentRankings(
       List<Ranking> rawRankings,

--- a/src/main/java/de/hdawg/rankinginfo/web/PlayerProfileService.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/PlayerProfileService.java
@@ -3,6 +3,7 @@ package de.hdawg.rankinginfo.web;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -37,7 +38,14 @@ public class PlayerProfileService {
       List<CompleteRankingRow> completeRankings,
       DiagramDataView allTimeDiagram,
       DiagramDataView recent12mDiagram,
-      Map<Integer, Set<String>> availableData) {}
+      Map<Integer, Set<String>> availableData) {
+
+    public PlayerProfile {
+      currentRankings = List.copyOf(currentRankings);
+      completeRankings = List.copyOf(completeRankings);
+      availableData = Collections.unmodifiableMap(new LinkedHashMap<>(availableData));
+    }
+  }
 
   @Nullable private final RankingRepository rankingRepository;
 

--- a/src/test/java/de/hdawg/rankinginfo/web/PlayerProfileServiceTest.java
+++ b/src/test/java/de/hdawg/rankinginfo/web/PlayerProfileServiceTest.java
@@ -17,7 +17,7 @@ import de.hdawg.rankinginfo.web.viewmodel.CompleteRankingRow;
 
 class PlayerProfileServiceTest {
 
-  private final PlayerProfileService service = new PlayerProfileService();
+  private final PlayerProfileService service = new PlayerProfileService(null);
 
   private static Ranking r(int dtbId, String ageGroup, LocalDate date, int pos, String score) {
     return new Ranking(0L, dtbId, "Test", "Player", "GER", ageGroup, date, pos, score, "TC Test", "HH",


### PR DESCRIPTION
## Summary

- Decouples `PlayerController` by extracting view-model assembly into `PlayerProfileService`, separating web-tier orchestration from business logic
- Centralises DTB ID encoding/decoding into a dedicated `RankingCoding` domain utility
- Introduces `@EvictImportCaches` meta-annotation to consolidate cache eviction across import paths
- Fixes SpotBugs EI_EXPOSE_REP/EI_EXPOSE_REP2 findings on `PlayerProfile` record by adding a compact constructor with defensive copies

## Test plan

- [x] All 160 existing tests pass (`./mvnw test`)
- [x] Spotless and PMD clean (`./mvnw spotless:check pmd:check`)
- [x] SpotBugs clean (`./mvnw verify`)
- [x] Player profile page renders correctly with current and historical ranking data