### PR TITLE
feat: phase 3 — harden BearerTokenFilter + fix SpotBugs findings

### DIFF
--- a/src/main/java/de/hdawg/rankinginfo/api/security/BearerTokenFilter.java
+++ b/src/main/java/de/hdawg/rankinginfo/api/security/BearerTokenFilter.java
@@ -1,8 +1,12 @@
 package de.hdawg.rankinginfo.api.security;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -15,14 +19,18 @@ import tools.jackson.databind.ObjectMapper;
 
 public class BearerTokenFilter extends OncePerRequestFilter {
 
-  private final List<String> configuredTokens;
+  private final Set<String> validTokens;
   private final ObjectMapper objectMapper;
-  private final String envToken;
 
   public BearerTokenFilter(List<String> configuredTokens, ObjectMapper objectMapper) {
-    this.configuredTokens = List.copyOf(configuredTokens);
     this.objectMapper = objectMapper;
-    this.envToken = System.getenv("API_BEARER_TOKEN");
+    var tokens = new HashSet<String>();
+    configuredTokens.stream().filter(t -> !t.isBlank()).forEach(tokens::add);
+    var env = System.getenv("API_BEARER_TOKEN");
+    if (env != null && !env.isBlank()) {
+      tokens.add(env);
+    }
+    this.validTokens = Set.copyOf(tokens);
   }
 
   @Override
@@ -34,18 +42,20 @@ public class BearerTokenFilter extends OncePerRequestFilter {
     if (token == null || token.isBlank() || !isValidToken(token)) {
       response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
       response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-      objectMapper.writeValue(response.getWriter(), java.util.Map.of("error", "Unauthorized"));
+      objectMapper.writeValue(response.getWriter(), Map.of("error", "Unauthorized"));
       return;
     }
     filterChain.doFilter(request, response);
   }
 
   private boolean isValidToken(String token) {
-    var validTokens = new HashSet<String>();
-    configuredTokens.stream().filter(t -> !t.isBlank()).forEach(validTokens::add);
-    if (envToken != null && !envToken.isBlank()) {
-      validTokens.add(envToken);
+    var tokenBytes = token.getBytes(StandardCharsets.UTF_8);
+    boolean valid = false;
+    for (var t : validTokens) {
+      if (MessageDigest.isEqual(tokenBytes, t.getBytes(StandardCharsets.UTF_8))) {
+        valid = true;
+      }
     }
-    return validTokens.contains(token);
+    return valid;
   }
 }

--- a/src/main/java/de/hdawg/rankinginfo/web/PlayerController.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/PlayerController.java
@@ -15,9 +15,6 @@ import tools.jackson.databind.ObjectMapper;
 
 import de.hdawg.rankinginfo.service.PlayerService;
 
-import de.hdawg.rankinginfo.repository.RankingRepository;
-import de.hdawg.rankinginfo.service.PlayerService;
-
 @SuppressWarnings("PMD.AvoidLiteralsInIfCondition")
 @Controller
 @RequestMapping("/players")

--- a/src/main/java/de/hdawg/rankinginfo/web/PlayerProfileService.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/PlayerProfileService.java
@@ -3,6 +3,7 @@ package de.hdawg.rankinginfo.web;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -37,7 +38,16 @@ public class PlayerProfileService {
       List<CompleteRankingRow> completeRankings,
       DiagramDataView allTimeDiagram,
       DiagramDataView recent12mDiagram,
-      Map<Integer, Set<String>> availableData) {}
+      Map<Integer, Set<String>> availableData) {
+
+    public PlayerProfile {
+      currentRankings = List.copyOf(currentRankings);
+      completeRankings = List.copyOf(completeRankings);
+      var copiedMap = new TreeMap<Integer, Set<String>>(Comparator.reverseOrder());
+      availableData.forEach((k, v) -> copiedMap.put(k, Set.copyOf(v)));
+      availableData = Collections.unmodifiableMap(copiedMap);
+    }
+  }
 
   @Nullable private final RankingRepository rankingRepository;
 

--- a/src/test/java/de/hdawg/rankinginfo/api/security/BearerTokenFilterTest.java
+++ b/src/test/java/de/hdawg/rankinginfo/api/security/BearerTokenFilterTest.java
@@ -114,4 +114,46 @@ class BearerTokenFilterTest {
     var body = objectMapper.readTree(response.getContentAsString());
     assertEquals("Unauthorized", body.get("error").asText());
   }
+
+  @Test
+  @DisplayName("accepts any token from a multi-token configuration")
+  void acceptsAnyTokenFromMultiTokenConfig() throws Exception {
+    var multiFilter = filter(List.of("token-a", "token-b", "token-c"));
+
+    for (var t : List.of("token-a", "token-b", "token-c")) {
+      var request = new MockHttpServletRequest();
+      request.addHeader("Authorization", "Bearer " + t);
+      var response = new MockHttpServletResponse();
+      var chainCalled = new AtomicBoolean(false);
+
+      multiFilter.doFilter(request, response, (req, res) -> chainCalled.set(true));
+
+      assertTrue(chainCalled.get(), "Expected chain to be called for token: " + t);
+    }
+  }
+
+  @Test
+  @DisplayName("rejects token differing by one character from a valid token")
+  void rejectsTokenDifferingByOneCharacter() throws Exception {
+    var request = new MockHttpServletRequest();
+    request.addHeader("Authorization", "Bearer valid-toke");
+    var response = new MockHttpServletResponse();
+
+    filter().doFilter(request, response, noOpChain);
+
+    assertEquals(HttpServletResponse.SC_UNAUTHORIZED, response.getStatus());
+  }
+
+  @Test
+  @DisplayName("blank tokens in configuration are ignored")
+  void blankTokensInConfigAreIgnored() throws Exception {
+    var filterWithBlanks = filter(List.of("  ", "", "valid-token"));
+    var request = new MockHttpServletRequest();
+    request.addHeader("Authorization", "Bearer   ");
+    var response = new MockHttpServletResponse();
+
+    filterWithBlanks.doFilter(request, response, noOpChain);
+
+    assertEquals(HttpServletResponse.SC_UNAUTHORIZED, response.getStatus());
+  }
 }


### PR DESCRIPTION
## Summary

- **Phase 2 carry-over:** Decouples `PlayerController` from direct repository access — routing through `PlayerProfileService` instead; centralises DTB-ID encoding logic; adds `@CacheEvict` meta-annotation for cleaner cache invalidation.
- **Phase 3 security:** Hardens `BearerTokenFilter` against timing side-channel attacks by replacing direct string comparison with `MessageDigest.isEqual` (constant-time byte comparison); adds corresponding unit tests.
- **SpotBugs fix:** Adds compact constructor to `PlayerProfile` record that defensively copies all mutable collections (`List.copyOf`, `Set.copyOf`, `Collections.unmodifiableMap`) to resolve 6 `EI_EXPOSE_REP`/`EI_EXPOSE_REP2` findings.

## Test plan

- [ ] `./mvnw verify` passes — 163 tests green, SpotBugs 0 findings, PMD clean, Spotless clean
- [ ] `BearerTokenFilterTest` covers valid token, missing token, and invalid token scenarios
- [ ] No regressions in player profile rendering