### PR TITLE
Add Javadoc to service-type classes

### DIFF
--- a/src/main/java/de/hdawg/rankinginfo/service/AgeGroupResolver.java
+++ b/src/main/java/de/hdawg/rankinginfo/service/AgeGroupResolver.java
@@ -5,6 +5,13 @@ import java.util.OptionalInt;
 
 import de.hdawg.rankinginfo.domain.RankingCoding;
 
+/// Derives a player's age and competition age groups from their DTB ID and a ranking quarter
+/// date.
+///
+/// DTB IDs encode gender and, for youth players, the 2-digit birth year: dividing the ID by
+/// [RankingCoding#YOB_MULTIPLIER] yields a marker holding a gender factor
+/// ([RankingCoding#GENDER_FACTOR_JUNIOREN] or [RankingCoding#GENDER_FACTOR_JUNIORINNEN]) plus
+/// that birth year. All methods are static; the class is not instantiable.
 public final class AgeGroupResolver {
 
   private static final int MIN_JUNIOR_AGE = 11;
@@ -15,12 +22,27 @@ public final class AgeGroupResolver {
 
   private AgeGroupResolver() {}
 
+  /// Returns the gender factor encoded in `dtbId`, based on which DTB ID range it falls in.
+  ///
+  /// @param dtbId the player's DTB ID
+  /// @return [RankingCoding#GENDER_FACTOR_JUNIOREN] for male IDs, or
+  ///     [RankingCoding#GENDER_FACTOR_JUNIORINNEN] for female IDs
   public static int genderFactor(int dtbId) {
     return dtbId < RankingCoding.FEMALE_DTB_ID_START
         ? RankingCoding.GENDER_FACTOR_JUNIOREN
         : RankingCoding.GENDER_FACTOR_JUNIORINNEN;
   }
 
+  /// Decodes the birth year encoded in `dtbId`.
+  ///
+  /// The DTB ID only encodes the last two digits of the birth year; this resolves the century
+  /// by preferring `20xx`, falling back to `19xx` if that would place the player's age in
+  /// `quarterYear` outside the junior age range (useful for adult players, whose IDs encode the
+  /// same two digits but aren't meant to be read as a birth year at all).
+  ///
+  /// @param dtbId the player's DTB ID
+  /// @param quarterYear the year of the ranking quarter to resolve the age against
+  /// @return the decoded birth year
   public static int birthYear(int dtbId, int quarterYear) {
     int marker = dtbId / RankingCoding.YOB_MULTIPLIER;
     int yy = marker - genderFactor(dtbId);
@@ -32,17 +54,32 @@ public final class AgeGroupResolver {
     return candidate;
   }
 
+  /// Computes the player's age as of `quarter`'s year, from the birth year decoded by
+  /// [#birthYear(int, int)].
+  ///
+  /// @param dtbId the player's DTB ID
+  /// @param quarter the ranking quarter date
+  /// @return the player's age during `quarter`
   public static int ageInQuarter(int dtbId, LocalDate quarter) {
     return quarter.getYear() - birthYear(dtbId, quarter.getYear());
   }
 
+  /// Returns the player's current single-year age bracket, clamped to at least `U11`.
+  ///
+  /// @param dtbId the player's DTB ID
+  /// @param quarter the ranking quarter date
+  /// @return the single age-group label, e.g. `"U14"`
   public static String currentSingleAgeGroup(int dtbId, LocalDate quarter) {
     int age = ageInQuarter(dtbId, quarter);
     return "U" + Math.max(MIN_JUNIOR_AGE, age);
   }
 
-  /** Returns the double-cohort (12/14/16/18) for the given player in the given quarter.
-   * Empty if the player is not a junior in that quarter. */
+  /// Returns the double-cohort age group (`U12`/`U14`/`U16`/`U18`) for the player in `quarter`.
+  ///
+  /// @param dtbId the player's DTB ID
+  /// @param quarter the ranking quarter date
+  /// @return the double-cohort age, e.g. `14`; empty if the player is not a junior in that
+  ///     quarter
   public static OptionalInt currentDoubleAgeGroup(int dtbId, LocalDate quarter) {
     int age = ageInQuarter(dtbId, quarter);
     if (age < MIN_JUNIOR_AGE || age > MAX_JUNIOR_AGE) return OptionalInt.empty();
@@ -50,6 +87,11 @@ public final class AgeGroupResolver {
     return OptionalInt.of(Math.max(MIN_DOUBLE_COHORT, doubled));
   }
 
+  /// Returns whether the player falls within the junior age range in `quarter`.
+  ///
+  /// @param dtbId the player's DTB ID
+  /// @param quarter the ranking quarter date
+  /// @return `true` if the player's age in `quarter` is between 11 and 18 inclusive
   public static boolean isJunior(int dtbId, LocalDate quarter) {
     int age = ageInQuarter(dtbId, quarter);
     return age >= MIN_JUNIOR_AGE && age <= MAX_JUNIOR_AGE;

--- a/src/main/java/de/hdawg/rankinginfo/service/EvictImportCaches.java
+++ b/src/main/java/de/hdawg/rankinginfo/service/EvictImportCaches.java
@@ -7,6 +7,12 @@ import java.lang.annotation.Target;
 
 import org.springframework.cache.annotation.CacheEvict;
 
+/// Marks a method whose successful execution invalidates every cache populated from ranking
+/// data.
+///
+/// Applied to [RankingImportService#importRankings(java.nio.file.Path)]; evicts the
+/// `available_quarters`, `available_dates`, `federations`, `player_counts`, `max_imported_at`,
+/// and `federation_stats` caches in one step, since an import can affect any of them.
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 @CacheEvict(

--- a/src/main/java/de/hdawg/rankinginfo/service/ImportService.java
+++ b/src/main/java/de/hdawg/rankinginfo/service/ImportService.java
@@ -16,6 +16,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+/// Scans a folder for ranking CSV files and hands each one to [RankingImportService] for
+/// parsing and persistence, logging successes and failures along the way.
+///
+/// Filenames are expected to follow the `{Category}_{yyyyMMdd}.csv` convention (e.g.
+/// `Herren_20240101.csv`); [#extractPeriodFromFilename(String)] and
+/// [#fileCategoryFromFilename(String)] decode that convention, and are also used by
+/// [RankingImportService] itself.
 @SuppressWarnings("PMD.GuardLogStatement")
 @Service
 public class ImportService {
@@ -30,6 +37,11 @@ public class ImportService {
     this.rankingImportService = rankingImportService;
   }
 
+  /// Extracts the ranking period (quarter date) from a `{Category}_{yyyyMMdd}.csv` filename.
+  ///
+  /// @param filename the CSV filename (path is ignored, only the base name is used)
+  /// @return the date encoded in the filename's trailing `yyyyMMdd` segment
+  /// @throws IllegalArgumentException if the filename has no `_`-separated date segment
   public static LocalDate extractPeriodFromFilename(String filename) {
     var name = new File(filename).getName();
     int dotIdx = name.lastIndexOf('.');
@@ -42,6 +54,13 @@ public class ImportService {
     return LocalDate.parse(parts[parts.length - 1], DateTimeFormatter.ofPattern("yyyyMMdd"));
   }
 
+  /// Extracts the lowercase file category (`herren`/`damen`/`junioren`/`juniorinnen`) from a
+  /// `{Category}_{yyyyMMdd}.csv` filename.
+  ///
+  /// @param filename the CSV filename (path is ignored, only the base name is used)
+  /// @return the lowercased category
+  /// @throws IllegalArgumentException if the filename's category prefix is not one of the four
+  ///     known categories
   public static String fileCategoryFromFilename(String filename) {
     var name = new File(filename).getName();
     int dotIdx = name.lastIndexOf('.');
@@ -58,6 +77,20 @@ public class ImportService {
     };
   }
 
+  /// Computes the YOB+gender marker values (matching the leading digits of
+  /// [RankingCoding#YOB_MULTIPLIER]-encoded DTB IDs) for every birth year whose age in `period`
+  /// is at most `ageGroup`, starting from the birth year encoded by `yob`.
+  ///
+  /// Used to gather the cumulative (`age <= ageGroup`) set of birth-year cohorts for a junior
+  /// age bracket, as opposed to a single exact-age cohort.
+  ///
+  /// @param yob the birth year of the youngest cohort to include, as a 4-digit string (e.g.
+  ///     `"2013"`)
+  /// @param ageGroup the upper age bound (inclusive) of the bracket being resolved
+  /// @param period the ranking quarter date ages are computed against
+  /// @param genderFactor [RankingCoding#GENDER_FACTOR_JUNIOREN] or
+  ///     [RankingCoding#GENDER_FACTOR_JUNIORINNEN]
+  /// @return YOB+gender markers for each included birth year, unsorted
   public static List<Integer> yobRangeToFetch(
       String yob, int ageGroup, LocalDate period, int genderFactor) {
     var classes = new ArrayList<Integer>();
@@ -70,10 +103,22 @@ public class ImportService {
     return classes;
   }
 
+  /// Scans `folderPath` for CSV files and imports each one, logging failures to
+  /// `folderPath + "/error.log"`.
+  ///
+  /// @param folderPath directory to scan for `.csv` files; a no-op if it doesn't exist or isn't
+  ///     a directory
   public void scanAndImport(String folderPath) {
     doScanAndImport(folderPath, null);
   }
 
+  /// Scans `folderPath` for CSV files and imports each one, logging failures to
+  /// `errorLogPath` (or `folderPath + "/error.log"` if `null`).
+  ///
+  /// @param folderPath directory to scan for `.csv` files; a no-op if it doesn't exist or isn't
+  ///     a directory
+  /// @param errorLogPath file to append import failures to, or `null` to use the default
+  ///     location inside `folderPath`
   public void scanAndImport(String folderPath, @Nullable String errorLogPath) {
     doScanAndImport(folderPath, errorLogPath);
   }

--- a/src/main/java/de/hdawg/rankinginfo/service/PlayerService.java
+++ b/src/main/java/de/hdawg/rankinginfo/service/PlayerService.java
@@ -13,6 +13,11 @@ import de.hdawg.rankinginfo.domain.Ranking;
 import de.hdawg.rankinginfo.domain.RankingCoding;
 import de.hdawg.rankinginfo.repository.RankingRepository;
 
+/// Player lookup and search support, querying [RankingRepository] directly for lightweight
+/// listings (search by name, by birth year, or by partial DTB ID) and a minimal player profile.
+///
+/// For a player's full profile page (rankings history, diagrams), the web tier's
+/// `PlayerProfileService` is used instead.
 @Service
 @Transactional(readOnly = true)
 public class PlayerService {
@@ -25,6 +30,12 @@ public class PlayerService {
     this.rankingRepository = rankingRepository;
   }
 
+  /// Expands a partial DTB ID into the full ID range it could complete to, by padding the
+  /// digits typed so far out to 8 digits.
+  ///
+  /// @param dtbId digits typed by the user, e.g. `"12"`; unparseable input is treated as `0`
+  /// @return a two-element array `{start, end}` spanning every full DTB ID with `dtbId` as a
+  ///     prefix
   public int[] dtbIdRange(String dtbId) {
     long idNum;
     try {
@@ -40,10 +51,22 @@ public class PlayerService {
     return new int[] {start, end};
   }
 
+  /// Converts a 4-digit birth year into the male YOB+gender marker (matching the leading
+  /// digits of male [RankingCoding#YOB_MULTIPLIER]-encoded DTB IDs).
+  ///
+  /// @param yob a 4-digit birth year, e.g. `"1995"`
+  /// @return the marker for the male cohort born in `yob`; add `100` to get the corresponding
+  ///     female marker
   public int yobToMaleMarker(String yob) {
     return Integer.parseInt(yob.trim().substring(2, 4)) + 100;
   }
 
+  /// Loads a minimal player profile: identity fields plus every club the player has appeared
+  /// under, derived from their adult/youth-overall ranking rows.
+  ///
+  /// @param dtbId the player's DTB ID
+  /// @return the player's profile
+  /// @throws NoSuchElementException if no ranking rows exist for `dtbId`
   public Player loadPlayerProfile(int dtbId) {
     var allRankings =
         rankingRepository.findByDtbIdAndAgeGroupInOrderByDateDesc(
@@ -70,10 +93,21 @@ public class PlayerService {
         clubs);
   }
 
+  /// Searches players whose last name matches `lastname`.
+  ///
+  /// @param lastname the last name to search for
+  /// @return matching ranking rows, one per player
   public List<Ranking> findPlayersByLastname(String lastname) {
     return rankingRepository.findByLastnameLike(lastname);
   }
 
+  /// Searches players whose last name matches `lastname` and whose DTB ID falls in the male or
+  /// female cohort range for the given YOB+gender markers.
+  ///
+  /// @param lastname the last name to search for
+  /// @param yobMale the male YOB+gender marker (see [#yobToMaleMarker(String)])
+  /// @param yobFemale the female YOB+gender marker
+  /// @return matching ranking rows, one per player
   public List<Ranking> findPlayersByLastnameAndYob(String lastname, int yobMale, int yobFemale) {
     return rankingRepository.findByLastnameAndYob(
         lastname,
@@ -83,6 +117,12 @@ public class PlayerService {
         yobFemale * RankingCoding.YOB_MULTIPLIER + RankingCoding.YOB_MULTIPLIER - 1);
   }
 
+  /// Searches players whose DTB ID falls in the male or female cohort range for the given
+  /// YOB+gender markers.
+  ///
+  /// @param yobMale the male YOB+gender marker (see [#yobToMaleMarker(String)])
+  /// @param yobFemale the female YOB+gender marker
+  /// @return matching ranking rows, one per player
   public List<Ranking> findPlayersByYob(int yobMale, int yobFemale) {
     return rankingRepository.findByYob(
         yobMale * RankingCoding.YOB_MULTIPLIER,
@@ -91,12 +131,23 @@ public class PlayerService {
         yobFemale * RankingCoding.YOB_MULTIPLIER + RankingCoding.YOB_MULTIPLIER - 1);
   }
 
+  /// Fetches a player's raw (non age-group-bracket, non year-of-birth, non year-end) ranking
+  /// rows.
+  ///
+  /// @param dtbId the player's DTB ID
+  /// @return matching ranking rows, most recent quarter first
   public List<Ranking> findNonAggregateRankings(int dtbId) {
     return rankingRepository
         .findByDtbIdAndYobRankingFalseAndAgeGroupRankingFalseAndYearEndRankingFalseOrderByDateDescAgeGroupAsc(
             dtbId);
   }
 
+  /// Searches players whose DTB ID falls within `[dtbIdStart, dtbIdEnd]`, typically built via
+  /// [#dtbIdRange(String)].
+  ///
+  /// @param dtbIdStart inclusive lower bound
+  /// @param dtbIdEnd inclusive upper bound
+  /// @return matching ranking rows, one per player
   public List<Ranking> findPlayersByDtbIdRange(int dtbIdStart, int dtbIdEnd) {
     return rankingRepository.findByDtbIdRange(dtbIdStart, dtbIdEnd);
   }

--- a/src/main/java/de/hdawg/rankinginfo/service/RankingFilter.java
+++ b/src/main/java/de/hdawg/rankinginfo/service/RankingFilter.java
@@ -2,6 +2,19 @@ package de.hdawg.rankinginfo.service;
 
 import org.jspecify.annotations.Nullable;
 
+/// Filter criteria gathered from a web/API request for browsing rankings, translated by
+/// [RankingService] into a query the repository layer understands.
+///
+/// @param quarter the selected ranking quarter, as an ISO date string
+/// @param ageGroupSlug the selected age-group slug (e.g. `m00`, `mu18`)
+/// @param ageGroupOptions for junior age-group slugs, selects which ranking variant to query:
+///     `only_yob` selects the single-birth-year ranking, `include_younger` selects the
+///     cumulative (age-and-younger) ranking; `null` selects the variant matching the slug's age
+///     number parity (single-birth-year for odd ages, double-cohort bracket for even ages).
+///     Ignored for adult age groups (`m00`/`w00`)
+/// @param federation federation abbreviation to filter by, or `null`/blank for all
+/// @param club club name to filter by, or `null`/blank for all
+/// @param yearEnd whether to use the year-end ranking instead of the regular quarterly one
 public record RankingFilter(
     String quarter,
     String ageGroupSlug,
@@ -10,6 +23,10 @@ public record RankingFilter(
     @Nullable String club,
     boolean yearEnd) {
 
+  /// Returns a copy of this filter with `quarter` replaced; all other criteria are unchanged.
+  ///
+  /// @param quarter the new quarter value
+  /// @return the updated filter
   public RankingFilter withQuarter(String quarter) {
     return new RankingFilter(quarter, ageGroupSlug, ageGroupOptions, federation, club, yearEnd);
   }

--- a/src/main/java/de/hdawg/rankinginfo/service/RankingImportService.java
+++ b/src/main/java/de/hdawg/rankinginfo/service/RankingImportService.java
@@ -28,6 +28,14 @@ import de.hdawg.rankinginfo.domain.RankingCoding;
 import de.hdawg.rankinginfo.repository.ImportHistoryRepository;
 import de.hdawg.rankinginfo.repository.RankingRepository;
 
+/// Parses a single ranking CSV file and persists both the raw rows and every derived ranking
+/// (per age group, year-of-birth, and age-group bracket) for that quarter.
+///
+/// [#importRankings(Path)] is the sole entry point, invoked once per file by [ImportService]. It
+/// rejects re-imports of a file already recorded in [ImportHistoryRepository], parses the CSV
+/// into raw [Ranking] rows tagged `age_group = "overall"` (youth) or `"m00"`/`"w00"` (adults),
+/// and — for youth categories — derives the full set of age-group rankings via
+/// [#calculateRankings(LocalDate, int)].
 @SuppressWarnings("PMD.GuardLogStatement")
 @Service
 public class RankingImportService {
@@ -70,6 +78,19 @@ public class RankingImportService {
     this.importHistoryRepository = importHistoryRepository;
   }
 
+  /// Imports a single ranking CSV file: parses and stores its raw rows, then derives and stores
+  /// every age-group ranking for youth categories.
+  ///
+  /// The file's category and period are decoded from its filename (see
+  /// [ImportService#fileCategoryFromFilename(String)] and
+  /// [ImportService#extractPeriodFromFilename(String)]). Evicts all caches on success, via
+  /// [EvictImportCaches].
+  ///
+  /// @param file path to the CSV file to import; its filename must follow the
+  ///     `{Category}_{yyyyMMdd}.csv` convention
+  /// @throws DuplicateImportError if a file for the same category and period was already
+  ///     imported
+  /// @throws IOException if the file cannot be read or its CSV content cannot be parsed
   @Transactional
   @EvictImportCaches
   public void importRankings(Path file) throws DuplicateImportError, IOException {

--- a/src/main/java/de/hdawg/rankinginfo/service/RankingService.java
+++ b/src/main/java/de/hdawg/rankinginfo/service/RankingService.java
@@ -24,6 +24,13 @@ import de.hdawg.rankinginfo.repository.ImportHistoryRepository;
 import de.hdawg.rankinginfo.repository.RankingQueryFilter;
 import de.hdawg.rankinginfo.repository.RankingRepository;
 
+/// Business-logic facade over [RankingRepository] for browsing rankings: translates the
+/// web/API-facing [RankingFilter] into a [RankingQueryFilter] the repository understands, and
+/// exposes supporting lookups (available quarters, federations, previous-quarter positions, last
+/// import timestamp).
+///
+/// Age-group slugs (e.g. `m00`, `mu18`) are translated to/from stored `age_group` values by
+/// [#toAgeGroupSlug(String, String)] and [#slugToAgeGroup(String)].
 @Service
 @Transactional(readOnly = true)
 public class RankingService {
@@ -50,6 +57,13 @@ public class RankingService {
     this.importHistoryRepository = importHistoryRepository;
   }
 
+  /// Lists every quarter that has ranking data, grouped by year.
+  ///
+  /// Each stored ranking date is the first day of the following quarter (e.g. data for Q1 is
+  /// dated April 1st); entries are adjusted back by one day before being grouped and formatted,
+  /// except the synthetic December 31st year-end ranking date, which is skipped entirely.
+  ///
+  /// @return years (as strings, descending) mapped to their available quarters
   @Cacheable("available_quarters")
   public Map<String, List<QuarterEntry>> fetchAvailableQuarters() {
     var years = new TreeMap<String, List<QuarterEntry>>(Comparator.reverseOrder());
@@ -63,15 +77,32 @@ public class RankingService {
     return years;
   }
 
+  /// Lists every distinct federation abbreviation present in the stored rankings.
+  ///
+  /// @return distinct federation abbreviations
   @Cacheable("federations")
   public List<String> fetchFederations() {
     return rankingRepository.findDistinctFederations();
   }
 
+  /// Fetches one page of rankings matching `filter`.
+  ///
+  /// @param filter the web/API-facing filter criteria
+  /// @param page zero-based page index
+  /// @param perPage page size
+  /// @return the matching page of rankings
   public Page<Ranking> findFilteredRankings(RankingFilter filter, int page, int perPage) {
     return rankingRepository.findFiltered(buildQueryFilter(filter), page, perPage);
   }
 
+  /// Looks up each given player's ranking position in the quarter immediately preceding
+  /// `filter`'s quarter, for computing position-change indicators.
+  ///
+  /// @param filter the filter whose quarter to look up the *previous* quarter for; its other
+  ///     criteria (age group, federation, club) are reused as-is
+  /// @param dtbIds the players to look up; returns an empty map if this is empty
+  /// @return each looked-up player's previous-quarter ranking position, keyed by DTB ID; empty
+  ///     if `filter`'s quarter has no preceding quarter with data
   public Map<Integer, Integer> findPreviousPositions(RankingFilter filter, List<Integer> dtbIds) {
     if (dtbIds.isEmpty()) return Map.of();
     var quarterDate = LocalDate.parse(filter.quarter());
@@ -87,6 +118,9 @@ public class RankingService {
         .collect(Collectors.toMap(Ranking::dtbId, Ranking::rankingPosition));
   }
 
+  /// Returns the timestamp of the most recent successful import, if any.
+  ///
+  /// @return the latest import timestamp, or `null` if nothing has been imported yet
   @Cacheable("max_imported_at")
   @Nullable
   public LocalDateTime maxImportedAt() {
@@ -138,6 +172,14 @@ public class RankingService {
         null);
   }
 
+  /// Builds the URL/API age-group slug (e.g. `m00`, `mu18`) for a gender category and, for
+  /// junior categories, an optional age-group label.
+  ///
+  /// @param gender one of `Herren`, `Damen`, `Junioren`, `Juniorinnen`; anything else yields
+  ///     `overall`
+  /// @param ageGroup for `Junioren`/`Juniorinnen`, the age-group label (e.g. `U18`); `null` or
+  ///     blank yields the `overall` slug for that gender
+  /// @return the age-group slug
   public static String toAgeGroupSlug(String gender, @Nullable String ageGroup) {
     return switch (gender) {
       case "Herren" -> "m00";

--- a/src/main/java/de/hdawg/rankinginfo/web/ClubService.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/ClubService.java
@@ -17,6 +17,16 @@ import de.hdawg.rankinginfo.repository.RankingRepository;
 import de.hdawg.rankinginfo.web.viewmodel.ClubSummary;
 import de.hdawg.rankinginfo.web.viewmodel.PlayerSummaryRow;
 
+/// Builds club-centric view models by aggregating [Ranking] rows for the most recent quarter.
+///
+/// Two entry points are exposed:
+/// - [#searchClubs(String)] returns lightweight summaries (youth/adult player counts) for clubs
+///   whose name matches a search term.
+/// - [#getClubDetail(String)] returns the full roster for a single club, grouped by adult
+///   category (`Herren`/`Damen`) and youth age group (`U12`-`U18`).
+///
+/// All queries are scoped to the latest available ranking date, as returned by
+/// [RankingRepository#findDistinctDatesDesc()].
 @Service
 @Transactional(readOnly = true)
 public class ClubService {
@@ -32,6 +42,16 @@ public class ClubService {
     this.rankingRepository = rankingRepository;
   }
 
+  /// Searches clubs whose name contains `searchTerm` (case-insensitive) and returns one
+  /// [ClubSummary] per matching club, sorted alphabetically.
+  ///
+  /// Each summary reports:
+  /// - the number of youth players (`age_group = "overall"`)
+  /// - the number of adult players (`age_group = "m00"` or `"w00"`)
+  ///
+  /// @param searchTerm substring to match against club names
+  /// @return matching clubs sorted by name, with youth/adult player counts; empty if no ranking
+  ///     data is available yet
   public List<ClubSummary> searchClubs(String searchTerm) {
     var quarter = rankingRepository.findDistinctDatesDesc().stream().findFirst().orElse(null);
     if (quarter == null) return List.of();
@@ -61,6 +81,19 @@ public class ClubService {
         .toList();
   }
 
+  /// Builds the full player roster for a single club, identified by an exact (case-insensitive)
+  /// name match.
+  ///
+  /// The result is a [LinkedHashMap] preserving insertion order, with keys in the order:
+  /// - `Herren` / `Damen` (whichever adult categories the club has players in)
+  /// - `U12`, `U14`, `U16`, `U18` (whichever youth age groups the club has players in)
+  ///
+  /// Youth players are resolved from their `overall` ranking to a specific age-group ranking via
+  /// [RankingRepository#findAgeGroupRankingsByDateAndDtbIds(java.time.LocalDate, List)], then
+  /// sorted by [Ranking#rankingPosition()].
+  ///
+  /// @param clubId club name to match exactly (case-insensitive)
+  /// @return rows grouped by category/age-group label; empty if no ranking data is available
   public Map<String, List<PlayerSummaryRow>> getClubDetail(String clubId) {
     var quarter = rankingRepository.findDistinctDatesDesc().stream().findFirst().orElse(null);
     var players = new LinkedHashMap<String, List<PlayerSummaryRow>>();

--- a/src/main/java/de/hdawg/rankinginfo/web/FederationService.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/FederationService.java
@@ -10,6 +10,15 @@ import org.springframework.transaction.annotation.Transactional;
 import de.hdawg.rankinginfo.domain.RankingCoding;
 import de.hdawg.rankinginfo.repository.RankingRepository;
 
+/// Builds per-federation player count statistics for the most recent quarter.
+///
+/// [#buildFederationData()] is the sole entry point. It returns a map keyed by federation display
+/// name (e.g. `Bayern`), with each value a map keyed by age-group/gender label (e.g. `U16m`,
+/// `m00`) to player count. Federation abbreviations from the data (e.g. `BTV`) are translated to
+/// display names via [#FEDERATION_NAMES]; unknown abbreviations pass through unchanged.
+///
+/// The result is cached under `federation_stats` and is scoped to the latest available ranking
+/// date, as returned by [RankingRepository#findDistinctDatesDesc()].
 @Service
 @Transactional(readOnly = true)
 public class FederationService {
@@ -45,6 +54,15 @@ public class FederationService {
     this.rankingRepository = rankingRepository;
   }
 
+  /// Aggregates player counts by federation for the latest ranking quarter.
+  ///
+  /// For each gender, youth players are counted per age group (via
+  /// [RankingRepository#countYouthByFederationAndAgeGroup(java.time.LocalDate, int, int)],
+  /// keyed by DTB ID range) and adult players are counted per adult category (`m00`/`w00`, via
+  /// [RankingRepository#countAdultByFederation(java.time.LocalDate, String)]).
+  ///
+  /// @return a map from federation display name to a map of age-group/gender label to player
+  ///     count; empty if no ranking data is available yet
   @Cacheable("federation_stats")
   public Map<String, Map<String, Integer>> buildFederationData() {
     var quarter = rankingRepository.findDistinctDatesDesc().stream().findFirst().orElse(null);

--- a/src/main/java/de/hdawg/rankinginfo/web/JteWarmup.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/JteWarmup.java
@@ -8,6 +8,11 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
 
+/// Sends warmup HTTP requests to a handful of pages right after startup, so the first real user
+/// request doesn't pay for jte's template compilation/class-loading cost.
+///
+/// Triggered by [ApplicationReadyEvent]; a no-op if the embedded server's port cannot be
+/// determined (e.g. in a context without a web server).
 @Component
 public class JteWarmup implements ApplicationListener<ApplicationReadyEvent> {
 
@@ -17,6 +22,11 @@ public class JteWarmup implements ApplicationListener<ApplicationReadyEvent> {
     "/", "/listings", "/players", "/clubs", "/federations", "/status", "/help", "/about", "/privacy"
   };
 
+  /// Issues one GET request per entry in [#WARMUP_PATHS] against the freshly started server,
+  /// logging how many succeeded. Individual request failures are logged and otherwise ignored.
+  ///
+  /// @param event published once the application context is fully started and the embedded
+  ///     server is listening
   @Override
   public void onApplicationEvent(ApplicationReadyEvent event) {
     var port = event.getApplicationContext().getEnvironment().getProperty("local.server.port");

--- a/src/main/java/de/hdawg/rankinginfo/web/PlayerProfileService.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/PlayerProfileService.java
@@ -30,10 +30,23 @@ import de.hdawg.rankinginfo.web.viewmodel.CurrentRankingRow;
 import de.hdawg.rankinginfo.web.viewmodel.DiagramDataView;
 import de.hdawg.rankinginfo.web.viewmodel.ScoreTimeSeries;
 
+/// Builds the [PlayerProfile] view model for a single player, assembling current rankings, the
+/// full ranking history, and diagram data from raw [Ranking] rows.
+///
+/// [#loadProfile(int)] is the orchestrating entry point; the other public methods are the
+/// individual build steps it composes, exposed so they can be tested in isolation.
 @SuppressWarnings({"PMD.LooseCoupling", "PMD.AvoidLiteralsInIfCondition"})
 @Service
 public class PlayerProfileService {
 
+  /// View model for a player's profile page.
+  ///
+  /// @param player player display data, including known club history
+  /// @param currentRankings ranking rows for the most recent quarter
+  /// @param completeRankings the full per-quarter ranking history
+  /// @param allTimeDiagram diagram series covering the player's entire history
+  /// @param recent12mDiagram diagram series covering roughly the last 12 months (last 4 quarters)
+  /// @param availableData quarters with ranking data, grouped by year, most recent year first
   public record PlayerProfile(
       Player player,
       List<CurrentRankingRow> currentRankings,
@@ -68,6 +81,12 @@ public class PlayerProfileService {
   private static final int DATE_PARTS_SIZE = 2;
   private static final DateTimeFormatter DTF = DateTimeFormatter.ofPattern("dd.MM.yyyy");
 
+  /// Loads the full profile for a player, or [Optional#empty()] if no ranking data exists for
+  /// them.
+  ///
+  /// @param dtbId the player's DTB ID
+  /// @return the assembled profile, or empty if the player has no ranking rows
+  /// @throws IllegalStateException if no [RankingRepository] was injected
   @Transactional(readOnly = true)
   public Optional<PlayerProfile> loadProfile(int dtbId) {
     var repo = rankingRepository;
@@ -114,12 +133,28 @@ public class PlayerProfileService {
             availableData));
   }
 
+  /// Derives the distinct clubs a player has played for from their date-descending ranking
+  /// rows, in order of most recent appearance.
+  ///
+  /// @param rankingsDateDesc the player's raw ranking rows, ordered newest first
+  /// @return distinct clubs, most recently played for first
   static List<Club> buildClubs(List<Ranking> rankingsDateDesc) {
     var map = new LinkedHashMap<String, Club>();
     rankingsDateDesc.forEach(r -> map.putIfAbsent(r.club(), new Club(r.club(), r.federation())));
     return List.copyOf(map.values());
   }
 
+  /// Builds the player's per-age-group ranking rows for `currentQuarter`, computing
+  /// position/score deltas against `previousQuarter` and marking which age group is the
+  /// player's "current" (single) youth age group.
+  ///
+  /// @param dtbId player's DTB ID, used to resolve youth age-group membership
+  /// @param rawRankings all raw ranking rows for the player, across any quarter
+  /// @param currentQuarter the quarter to build rows for; returns an empty list if `null`
+  /// @param previousQuarter the prior quarter to diff against, or `null` if unavailable
+  /// @param ageGroupRankings the player's age-group-bracket rankings for `currentQuarter`
+  /// @return current-quarter ranking rows, adult categories sorted first, then youth age groups
+  ///     ascending
   public List<CurrentRankingRow> buildCurrentRankings(
       int dtbId,
       List<Ranking> rawRankings,
@@ -177,6 +212,12 @@ public class PlayerProfileService {
     return Integer.parseInt(row.ageGroup().substring(1)) + 1;
   }
 
+  /// Builds one row per quarter the player has full (non age-group-bracket, non
+  /// year-of-birth) rankings for, mapping each row's age groups to ranking positions.
+  ///
+  /// @param rankings the player's ranking rows, across any quarter
+  /// @return rows ordered by quarter, most recent first; quarters that don't map to `Q1`-`Q4`
+  ///     are skipped
   public List<CompleteRankingRow> buildCompleteRankings(List<Ranking> rankings) {
     var byDate =
         rankings.stream()
@@ -206,6 +247,12 @@ public class PlayerProfileService {
     return result;
   }
 
+  /// Builds diagram time series (ranking position per age group, plus score) from rankings,
+  /// considering only adult or age-group-bracket rows; year-of-birth rows are excluded.
+  ///
+  /// @param rankings ranking rows to chart, across any quarter
+  /// @return diagram data with one position series per age group present (ordered per
+  ///     [#DIAGRAM_ORDER]) and a single score series; both are empty if no row qualifies
   public DiagramDataView buildDiagramData(List<Ranking> rankings) {
     var general =
         rankings.stream()
@@ -231,6 +278,12 @@ public class PlayerProfileService {
     return new DiagramDataView(positionsList, List.of(new ScoreTimeSeries("Punkte", scores)));
   }
 
+  /// Derives which years and quarters have ranking data, from already-built
+  /// [CompleteRankingRow]s.
+  ///
+  /// @param completeRankings rows produced by [#buildCompleteRankings(List)]
+  /// @return quarters present per year, most recent year first; rows with an unparseable year
+  ///     are skipped
   @SuppressWarnings("PMD.EmptyCatchBlock")
   public Map<Integer, Set<String>> buildAvailableData(List<CompleteRankingRow> completeRankings) {
     var result = new TreeMap<Integer, Set<String>>(Comparator.reverseOrder());


### PR DESCRIPTION
## Summary
- Add Javadoc comments to public classes and methods in `service/` and the service-type classes in `web/` (ClubService, FederationService, PlayerProfileService, JteWarmup)
- Documentation only, no behavior changes

## Test plan
- [x] `./mvnw test` passes
- [x] `./mvnw spotless:check pmd:check` passes