### PR TITLE
feat: add Maven Build Cache extension

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+  <extension>
+    <groupId>org.apache.maven.extensions</groupId>
+    <artifactId>maven-build-cache-extension</artifactId>
+    <version>1.2.0</version>
+  </extension>
+</extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>de.hdawg.tennis</groupId>
   <artifactId>ranking-info</artifactId>
-  <version>1.6.1</version>
+  <version>1.6.2</version>
   <name>ranking-info</name>
 
   <properties>


### PR DESCRIPTION
## Summary
- Adds `.mvn/extensions.xml` to register the `maven-build-cache-extension` (v1.2.0)
- Enables local disk caching of build outputs out of the box (no additional config required)
- Works with the existing Maven 3.9.16 wrapper
- Bumps version to 1.6.2

## Test plan
- [ ] Run `./mvnw validate` and confirm the build cache extension loads in the log output
- [ ] Run `./mvnw test` twice and confirm the second run uses cached results