### PR TITLE
Move api/v1 DTOs into dedicated dto subpackage

### DIFF
--- a/src/main/java/de/hdawg/rankinginfo/api/v1/ListingsApiController.java
+++ b/src/main/java/de/hdawg/rankinginfo/api/v1/ListingsApiController.java
@@ -15,6 +15,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import de.hdawg.rankinginfo.api.v1.dto.ListingItem;
+import de.hdawg.rankinginfo.api.v1.dto.ListingRequest;
+import de.hdawg.rankinginfo.api.v1.dto.ListingResponse;
+import de.hdawg.rankinginfo.api.v1.dto.PlayerLink;
 import de.hdawg.rankinginfo.domain.Ranking;
 import de.hdawg.rankinginfo.service.RankingFilter;
 import de.hdawg.rankinginfo.service.RankingService;

--- a/src/main/java/de/hdawg/rankinginfo/api/v1/PlayersApiController.java
+++ b/src/main/java/de/hdawg/rankinginfo/api/v1/PlayersApiController.java
@@ -14,6 +14,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import de.hdawg.rankinginfo.api.v1.dto.PlayerDetailData;
+import de.hdawg.rankinginfo.api.v1.dto.PlayerDetailResponse;
+import de.hdawg.rankinginfo.api.v1.dto.PlayerLink;
+import de.hdawg.rankinginfo.api.v1.dto.PlayerSearchItem;
+import de.hdawg.rankinginfo.api.v1.dto.PlayerSearchRequest;
+import de.hdawg.rankinginfo.api.v1.dto.PlayerSearchResponse;
+import de.hdawg.rankinginfo.api.v1.dto.RankingEntry;
 import de.hdawg.rankinginfo.domain.RankingCoding;
 import de.hdawg.rankinginfo.service.PlayerService;
 

--- a/src/main/java/de/hdawg/rankinginfo/api/v1/dto/ListingItem.java
+++ b/src/main/java/de/hdawg/rankinginfo/api/v1/dto/ListingItem.java
@@ -1,4 +1,4 @@
-package de.hdawg.rankinginfo.api.v1;
+package de.hdawg.rankinginfo.api.v1.dto;
 
 public record ListingItem(
     int dtb_id,

--- a/src/main/java/de/hdawg/rankinginfo/api/v1/dto/ListingRequest.java
+++ b/src/main/java/de/hdawg/rankinginfo/api/v1/dto/ListingRequest.java
@@ -1,4 +1,4 @@
-package de.hdawg.rankinginfo.api.v1;
+package de.hdawg.rankinginfo.api.v1.dto;
 
 public record ListingRequest(
     String quarter,

--- a/src/main/java/de/hdawg/rankinginfo/api/v1/dto/ListingResponse.java
+++ b/src/main/java/de/hdawg/rankinginfo/api/v1/dto/ListingResponse.java
@@ -1,4 +1,4 @@
-package de.hdawg.rankinginfo.api.v1;
+package de.hdawg.rankinginfo.api.v1.dto;
 
 import java.util.List;
 

--- a/src/main/java/de/hdawg/rankinginfo/api/v1/dto/PlayerDetailData.java
+++ b/src/main/java/de/hdawg/rankinginfo/api/v1/dto/PlayerDetailData.java
@@ -1,4 +1,4 @@
-package de.hdawg.rankinginfo.api.v1;
+package de.hdawg.rankinginfo.api.v1.dto;
 
 import java.util.List;
 

--- a/src/main/java/de/hdawg/rankinginfo/api/v1/dto/PlayerDetailResponse.java
+++ b/src/main/java/de/hdawg/rankinginfo/api/v1/dto/PlayerDetailResponse.java
@@ -1,3 +1,3 @@
-package de.hdawg.rankinginfo.api.v1;
+package de.hdawg.rankinginfo.api.v1.dto;
 
 public record PlayerDetailResponse(PlayerDetailData data) {}

--- a/src/main/java/de/hdawg/rankinginfo/api/v1/dto/PlayerLink.java
+++ b/src/main/java/de/hdawg/rankinginfo/api/v1/dto/PlayerLink.java
@@ -1,3 +1,3 @@
-package de.hdawg.rankinginfo.api.v1;
+package de.hdawg.rankinginfo.api.v1.dto;
 
 public record PlayerLink(String self) {}

--- a/src/main/java/de/hdawg/rankinginfo/api/v1/dto/PlayerSearchItem.java
+++ b/src/main/java/de/hdawg/rankinginfo/api/v1/dto/PlayerSearchItem.java
@@ -1,4 +1,4 @@
-package de.hdawg.rankinginfo.api.v1;
+package de.hdawg.rankinginfo.api.v1.dto;
 
 public record PlayerSearchItem(
     int dtb_id, String lastname, String firstname, String club, PlayerLink links) {}

--- a/src/main/java/de/hdawg/rankinginfo/api/v1/dto/PlayerSearchRequest.java
+++ b/src/main/java/de/hdawg/rankinginfo/api/v1/dto/PlayerSearchRequest.java
@@ -1,3 +1,3 @@
-package de.hdawg.rankinginfo.api.v1;
+package de.hdawg.rankinginfo.api.v1.dto;
 
 public record PlayerSearchRequest(String lastname, String yob, int total_count) {}

--- a/src/main/java/de/hdawg/rankinginfo/api/v1/dto/PlayerSearchResponse.java
+++ b/src/main/java/de/hdawg/rankinginfo/api/v1/dto/PlayerSearchResponse.java
@@ -1,4 +1,4 @@
-package de.hdawg.rankinginfo.api.v1;
+package de.hdawg.rankinginfo.api.v1.dto;
 
 import java.util.List;
 

--- a/src/main/java/de/hdawg/rankinginfo/api/v1/dto/RankingEntry.java
+++ b/src/main/java/de/hdawg/rankinginfo/api/v1/dto/RankingEntry.java
@@ -1,4 +1,4 @@
-package de.hdawg.rankinginfo.api.v1;
+package de.hdawg.rankinginfo.api.v1.dto;
 
 import java.time.LocalDate;
 

--- a/src/main/java/de/hdawg/rankinginfo/api/v1/dto/package-info.java
+++ b/src/main/java/de/hdawg/rankinginfo/api/v1/dto/package-info.java
@@ -1,0 +1,2 @@
+@org.jspecify.annotations.NullMarked
+package de.hdawg.rankinginfo.api.v1.dto;


### PR DESCRIPTION
## Summary
- Moved the 10 request/response records in `api.v1` (`ListingItem`, `ListingRequest`, `ListingResponse`, `PlayerDetailData`, `PlayerDetailResponse`, `PlayerLink`, `PlayerSearchItem`, `PlayerSearchRequest`, `PlayerSearchResponse`, `RankingEntry`) into a new `api.v1.dto` subpackage, mirroring the existing `web/viewmodel` pattern.
- Controllers (`ListingsApiController`, `PlayersApiController`) and `GlobalApiExceptionHandler` remain in `api.v1`; only their DTO imports changed.
- Pure structural move, no behavior change.

## Test plan
- [x] `./mvnw test`
- [x] `./mvnw spotless:check pmd:check`