### PR TITLE
feat: add REST API endpoints for clubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ Requests without a valid token receive `401 Unauthorized`. Exceeding 1000 reques
 | `GET /api/v1/listings/{quarter}/{age_group_slug}` | Paginated ranking list. Slug: `m00` Herren, `w00` Damen, `mu18` Junioren U18, `wu12` Juniorinnen U12, etc. |
 | `GET /api/v1/players?lastname=&yob=` | Player search by lastname (partial, case-insensitive) + optional year of birth |
 | `GET /api/v1/players/{dtb_id}` | Player profile with full ranking history |
+| `GET /api/v1/clubs?name=` | Club search by name (partial, case-insensitive) |
+| `GET /api/v1/clubs/{id}` | Club roster grouped by category/age group |
 
 Swagger UI: [http://localhost:8080/api-docs](http://localhost:8080/api-docs)
 

--- a/docs/superpowers/specs/2026-06-24-clubs-rest-api-design.md
+++ b/docs/superpowers/specs/2026-06-24-clubs-rest-api-design.md
@@ -1,0 +1,138 @@
+# Clubs REST API — Design
+
+## Goal
+
+Expose the existing `/clubs` web functionality (club search and club roster detail) as a REST API
+under `/api/v1/clubs`, following the same conventions already established by
+`PlayersApiController` (bearer-token auth, `ProblemDetail` errors, `request`/`data` response
+envelopes, snake_case JSON fields, `links.self` references to related resources).
+
+## Scope
+
+Two endpoints, mirroring `ClubController`'s two web routes:
+
+- `GET /clubs` (search by name substring) → `GET /api/v1/clubs?name=...`
+- `GET /clubs/{id}` (full roster for one club) → `GET /api/v1/clubs/{id}`
+
+No changes to `ClubService`, `SecurityConfig`, or `RateLimitFilter` — both new routes fall under
+the existing `/api/v1/**` bearer-token + rate-limit filter chain, and both delegate to the
+existing `ClubService.searchClubs(String)` / `ClubService.getClubDetail(String)` methods without
+modification.
+
+## Endpoints
+
+### `GET /api/v1/clubs?name={name}`
+
+Search clubs whose name contains `name` (case-insensitive substring match), same semantics as
+`ClubService.searchClubs`.
+
+- `name` blank or missing → `400 Bad Request`, `ProblemDetail` with detail `"name parameter
+  required"` (mirrors `PlayersApiController.search`'s `lastname` validation).
+- No matching clubs → `404 Not Found`, `ProblemDetail` with detail `"Not Found"`.
+- Otherwise → `200 OK` with:
+
+```json
+{
+  "request": { "name": "TC", "total_count": 2 },
+  "data": [
+    { "name": "TC Example", "youth_count": 3, "adult_count": 7 },
+    { "name": "TC Sample",  "youth_count": 0, "adult_count": 5 }
+  ]
+}
+```
+
+### `GET /api/v1/clubs/{id}`
+
+Full roster for one club, identified by exact (case-insensitive) name match — same semantics as
+`ClubService.getClubDetail`.
+
+- No players found for `id` (unknown/misspelled club name) → `404 Not Found`.
+- Otherwise → `200 OK` with the roster grouped by category, preserving the existing iteration
+  order (`Herren`/`Damen` first, then `U12`, `U14`, `U16`, `U18` — whichever groups are
+  non-empty):
+
+```json
+{
+  "data": {
+    "name": "TC Example",
+    "groups": [
+      {
+        "group": "Herren",
+        "players": [
+          {
+            "dtb_id": 10001001,
+            "lastname": "Mustermann",
+            "firstname": "Max",
+            "rank": 1,
+            "score": "1000",
+            "links": { "self": "/api/v1/players/10001001" }
+          }
+        ]
+      },
+      { "group": "U14", "players": [ ... ] }
+    ]
+  }
+}
+```
+
+## New types (package `de.hdawg.rankinginfo.api.v1`)
+
+- `ClubsApiController` — `@RestController`, `@RequestMapping("/api/v1/clubs")`,
+  `@SecurityRequirement(name = "bearerAuth")`. Two handler methods: `search` and `show`, structured
+  like the corresponding methods in `PlayersApiController`.
+- `ClubSearchItem(String name, int youth_count, int adult_count)`
+- `ClubSearchRequest(String name, int total_count)`
+- `ClubSearchResponse(ClubSearchRequest request, List<ClubSearchItem> data)` — defensive-copies
+  `data` like `PlayerSearchResponse` does.
+- `ClubDetailResponse(ClubDetailData data)`
+- `ClubDetailData(String name, List<ClubGroup> groups)`
+- `ClubGroup(String group, List<ClubPlayerItem> players)`
+- `ClubPlayerItem(int dtb_id, String lastname, String firstname, int rank, String score,
+  PlayerLink links)` — reuses the existing `PlayerLink(String self)` record.
+
+`ClubsApiController.show` builds `groups` from the `LinkedHashMap<String, List<PlayerSummaryRow>>`
+returned by `ClubService.getClubDetail`, preserving its key order. Each `PlayerSummaryRow` maps to
+a `ClubPlayerItem` with `links.self = "/api/v1/players/" + dtbId`.
+
+## Error handling
+
+Both endpoints rely on the existing `GlobalApiExceptionHandler` for generic errors; `400`/`404`
+responses are constructed explicitly in the controller, same as `PlayersApiController`.
+
+## Testing
+
+New `ClubsApiControllerTest` in `src/test/java/de/hdawg/rankinginfo/api/`, structured like
+`PlayersApiControllerTest`:
+
+- `search` returns `401` without a bearer token
+- `show` returns `401` without a bearer token
+- `search` returns `400` when `name` is missing/blank
+- `search` returns `404` when no club matches
+- `search` returns matching clubs with correct `youth_count`/`adult_count`
+- `search` is case-insensitive
+- `search` response contains `request` and `data` keys with required fields
+- `show` returns `404` for an unknown club id
+- `show` returns the roster for a known club, grouped correctly
+- `show` preserves group order (adult categories before youth age groups, youth groups in
+  `U12`/`U14`/`U16`/`U18` order)
+- `show` player items contain required fields including `links.self`
+
+Tests seed data via `RankingRepository` the same way `PlayersApiControllerTest` does, using the
+H2 in-memory test database — no new fixtures or external services needed.
+
+## Documentation
+
+`README.md`'s "Endpoints" table (around line 107) lists every existing `/api/v1` route. Add two
+rows for the new club endpoints, matching the existing style:
+
+```
+| `GET /api/v1/clubs?name=` | Club search by name (partial, case-insensitive) |
+| `GET /api/v1/clubs/{id}` | Club roster grouped by category/age group |
+```
+
+## Out of scope
+
+- No changes to the web `/clubs` controller, service, or templates.
+- No new caching beyond what `RankingRepository`/`ClubService` already provide.
+- No OpenAPI schema changes beyond the new `@Operation`/`@ApiResponse` annotations on the new
+  controller methods (following the existing pattern in `PlayersApiController`).

--- a/src/main/java/de/hdawg/rankinginfo/api/v1/ClubDetailData.java
+++ b/src/main/java/de/hdawg/rankinginfo/api/v1/ClubDetailData.java
@@ -1,0 +1,9 @@
+package de.hdawg.rankinginfo.api.v1;
+
+import java.util.List;
+
+public record ClubDetailData(String name, List<ClubGroup> groups) {
+  public ClubDetailData {
+    groups = List.copyOf(groups);
+  }
+}

--- a/src/main/java/de/hdawg/rankinginfo/api/v1/ClubDetailResponse.java
+++ b/src/main/java/de/hdawg/rankinginfo/api/v1/ClubDetailResponse.java
@@ -1,0 +1,3 @@
+package de.hdawg.rankinginfo.api.v1;
+
+public record ClubDetailResponse(ClubDetailData data) {}

--- a/src/main/java/de/hdawg/rankinginfo/api/v1/ClubGroup.java
+++ b/src/main/java/de/hdawg/rankinginfo/api/v1/ClubGroup.java
@@ -1,0 +1,9 @@
+package de.hdawg.rankinginfo.api.v1;
+
+import java.util.List;
+
+public record ClubGroup(String group, List<ClubPlayerItem> players) {
+  public ClubGroup {
+    players = List.copyOf(players);
+  }
+}

--- a/src/main/java/de/hdawg/rankinginfo/api/v1/ClubPlayerItem.java
+++ b/src/main/java/de/hdawg/rankinginfo/api/v1/ClubPlayerItem.java
@@ -1,0 +1,4 @@
+package de.hdawg.rankinginfo.api.v1;
+
+public record ClubPlayerItem(
+    int dtb_id, String lastname, String firstname, int rank, String score, PlayerLink links) {}

--- a/src/main/java/de/hdawg/rankinginfo/api/v1/ClubSearchItem.java
+++ b/src/main/java/de/hdawg/rankinginfo/api/v1/ClubSearchItem.java
@@ -1,0 +1,3 @@
+package de.hdawg.rankinginfo.api.v1;
+
+public record ClubSearchItem(String name, int youth_count, int adult_count) {}

--- a/src/main/java/de/hdawg/rankinginfo/api/v1/ClubSearchRequest.java
+++ b/src/main/java/de/hdawg/rankinginfo/api/v1/ClubSearchRequest.java
@@ -1,0 +1,3 @@
+package de.hdawg.rankinginfo.api.v1;
+
+public record ClubSearchRequest(String name, int total_count) {}

--- a/src/main/java/de/hdawg/rankinginfo/api/v1/ClubSearchResponse.java
+++ b/src/main/java/de/hdawg/rankinginfo/api/v1/ClubSearchResponse.java
@@ -1,0 +1,9 @@
+package de.hdawg.rankinginfo.api.v1;
+
+import java.util.List;
+
+public record ClubSearchResponse(ClubSearchRequest request, List<ClubSearchItem> data) {
+  public ClubSearchResponse {
+    data = List.copyOf(data);
+  }
+}

--- a/src/main/java/de/hdawg/rankinginfo/api/v1/ClubsApiController.java
+++ b/src/main/java/de/hdawg/rankinginfo/api/v1/ClubsApiController.java
@@ -1,0 +1,97 @@
+package de.hdawg.rankinginfo.api.v1;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import de.hdawg.rankinginfo.web.ClubService;
+
+@RestController
+@RequestMapping("/api/v1/clubs")
+@SecurityRequirement(name = "bearerAuth")
+public class ClubsApiController {
+
+  private final ClubService clubService;
+
+  public ClubsApiController(ClubService clubService) {
+    this.clubService = clubService;
+  }
+
+  @Operation(summary = "Search clubs by name")
+  @ApiResponse(
+      responseCode = "200",
+      content = @Content(schema = @Schema(implementation = ClubSearchResponse.class)))
+  @ApiResponse(
+      responseCode = "400",
+      content = @Content(schema = @Schema(implementation = ProblemDetail.class)))
+  @ApiResponse(
+      responseCode = "404",
+      content = @Content(schema = @Schema(implementation = ProblemDetail.class)))
+  @GetMapping
+  public ResponseEntity<Object> search(@RequestParam(required = false, defaultValue = "") String name) {
+    if (name.isBlank()) {
+      return ResponseEntity.badRequest()
+          .body(ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, "name parameter required"));
+    }
+
+    var clubs = clubService.searchClubs(name);
+    if (clubs.isEmpty()) {
+      return ResponseEntity.status(404)
+          .body(ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, "Not Found"));
+    }
+
+    var data =
+        clubs.stream()
+            .map(c -> new ClubSearchItem(c.name(), c.youthCount(), c.adultCount()))
+            .toList();
+
+    return ResponseEntity.ok(new ClubSearchResponse(new ClubSearchRequest(name, clubs.size()), data));
+  }
+
+  @Operation(summary = "Get club roster grouped by category and age group")
+  @ApiResponse(
+      responseCode = "200",
+      content = @Content(schema = @Schema(implementation = ClubDetailResponse.class)))
+  @ApiResponse(
+      responseCode = "404",
+      content = @Content(schema = @Schema(implementation = ProblemDetail.class)))
+  @GetMapping("/{id}")
+  public ResponseEntity<Object> show(@PathVariable String id) {
+    var roster = clubService.getClubDetail(id);
+    if (roster.isEmpty()) {
+      return ResponseEntity.status(404)
+          .body(ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, "Not Found"));
+    }
+
+    var groups =
+        roster.entrySet().stream()
+            .map(
+                e ->
+                    new ClubGroup(
+                        e.getKey(),
+                        e.getValue().stream()
+                            .map(
+                                p ->
+                                    new ClubPlayerItem(
+                                        p.dtbId(),
+                                        p.lastname(),
+                                        p.firstname(),
+                                        p.rank(),
+                                        p.score(),
+                                        new PlayerLink("/api/v1/players/" + p.dtbId())))
+                            .toList()))
+            .toList();
+
+    return ResponseEntity.ok(new ClubDetailResponse(new ClubDetailData(id, groups)));
+  }
+}

--- a/src/test/java/de/hdawg/rankinginfo/api/ClubsApiControllerTest.java
+++ b/src/test/java/de/hdawg/rankinginfo/api/ClubsApiControllerTest.java
@@ -1,0 +1,200 @@
+package de.hdawg.rankinginfo.api;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.test.web.servlet.MockMvc;
+
+import de.hdawg.rankinginfo.domain.Ranking;
+import de.hdawg.rankinginfo.repository.ImportHistoryRepository;
+import de.hdawg.rankinginfo.repository.RankingRepository;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class ClubsApiControllerTest {
+
+  @Autowired MockMvc mockMvc;
+
+  @Autowired RankingRepository rankingRepository;
+
+  @Autowired ImportHistoryRepository importHistoryRepository;
+
+  private final String auth = "Bearer test-api-token";
+  private final LocalDate q = LocalDate.of(2026, 4, 1);
+
+  @BeforeEach
+  void seed() {
+    rankingRepository.saveAll(
+        List.of(
+            // Herren, TC Example
+            r(10_001_001, "Mustermann", "Max", "m00", q, 1, "TC Example", false),
+            // Damen, TC Example
+            r(20_001_001, "Musterfrau", "Maxi", "w00", q, 1, "TC Example", false),
+            // Herren, TC Sample (different club, should not match "Example" search)
+            r(10_002_002, "Schmidt", "Peter", "m00", q, 1, "TC Sample", false),
+            // Youth overall ranking, TC Example
+            r(10_101_101, "Junior", "Jan", "overall", q, 5, "TC Example", false),
+            // Age-group resolution for the youth player above (U14)
+            r(10_101_101, "Junior", "Jan", "U14", q, 5, "TC Example", true)));
+  }
+
+  @AfterEach
+  void cleanup() {
+    rankingRepository.deleteAll();
+    importHistoryRepository.deleteAll();
+  }
+
+  // ── Auth ─────────────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("search returns 401 without token")
+  void searchReturns401WithoutToken() throws Exception {
+    mockMvc.perform(get("/api/v1/clubs?name=Example")).andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @DisplayName("show returns 401 without token")
+  void showReturns401WithoutToken() throws Exception {
+    mockMvc.perform(get("/api/v1/clubs/TC Example")).andExpect(status().isUnauthorized());
+  }
+
+  // ── Search ───────────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("search returns 400 when name missing")
+  void searchReturns400WhenNameMissing() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/clubs").header("Authorization", auth))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.detail").value("name parameter required"));
+  }
+
+  @Test
+  @DisplayName("search returns 404 when no club matches")
+  void searchReturns404WhenNoClubMatches() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/clubs?name=NichtVorhanden").header("Authorization", auth))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @DisplayName("search returns matching clubs by name")
+  void searchReturnsMatchingClubsByName() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/clubs?name=Example").header("Authorization", auth))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data[0].name").value("TC Example"));
+  }
+
+  @Test
+  @DisplayName("search is case-insensitive")
+  void searchIsCaseInsensitive() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/clubs?name=example").header("Authorization", auth))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data[0].name").value("TC Example"));
+  }
+
+  @Test
+  @DisplayName("search response contains request and data keys")
+  void searchResponseContainsRequestAndDataKeys() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/clubs?name=Example").header("Authorization", auth))
+        .andExpect(jsonPath("$.request.name").value("Example"))
+        .andExpect(jsonPath("$.request.total_count").isNumber())
+        .andExpect(jsonPath("$.data").isArray());
+  }
+
+  @Test
+  @DisplayName("search data entry contains required fields")
+  void searchDataEntryContainsRequiredFields() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/clubs?name=Example").header("Authorization", auth))
+        .andExpect(jsonPath("$.data[0].name").isString())
+        .andExpect(jsonPath("$.data[0].youth_count").isNumber())
+        .andExpect(jsonPath("$.data[0].adult_count").isNumber());
+  }
+
+  @Test
+  @DisplayName("search counts youth and adult players correctly")
+  void searchCountsYouthAndAdultPlayersCorrectly() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/clubs?name=Example").header("Authorization", auth))
+        .andExpect(jsonPath("$.data[0].youth_count").value(1))
+        .andExpect(jsonPath("$.data[0].adult_count").value(2));
+  }
+
+  // ── Show ─────────────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("show returns 404 for unknown club")
+  void showReturns404ForUnknownClub() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/clubs/Unknown Club").header("Authorization", auth))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @DisplayName("show returns roster grouped by category for known club")
+  void showReturnsRosterGroupedByCategoryForKnownClub() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/clubs/TC Example").header("Authorization", auth))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.name").value("TC Example"))
+        .andExpect(jsonPath("$.data.groups").isArray());
+  }
+
+  @Test
+  @DisplayName("show preserves group order: adult categories before youth age groups")
+  void showPreservesGroupOrder() throws Exception {
+    // ClubService.ADULT_LABELS is a Map.of(...), so Herren/Damen relative order is not
+    // guaranteed; only that both adult groups precede the youth U14 group is.
+    mockMvc
+        .perform(get("/api/v1/clubs/TC Example").header("Authorization", auth))
+        .andExpect(jsonPath("$.data.groups.length()").value(3))
+        .andExpect(jsonPath("$.data.groups[*].group").value(org.hamcrest.Matchers.hasItems("Herren", "Damen")))
+        .andExpect(jsonPath("$.data.groups[2].group").value("U14"));
+  }
+
+  @Test
+  @DisplayName("show player items contain required fields including links")
+  void showPlayerItemsContainRequiredFields() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/clubs/TC Example").header("Authorization", auth))
+        .andExpect(jsonPath("$.data.groups[2].group").value("U14"))
+        .andExpect(jsonPath("$.data.groups[2].players[0].dtb_id").value(10_101_101))
+        .andExpect(jsonPath("$.data.groups[2].players[0].lastname").value("Junior"))
+        .andExpect(jsonPath("$.data.groups[2].players[0].firstname").value("Jan"))
+        .andExpect(jsonPath("$.data.groups[2].players[0].rank").value(5))
+        .andExpect(jsonPath("$.data.groups[2].players[0].score").value("100"))
+        .andExpect(
+            jsonPath("$.data.groups[2].players[0].links.self").value("/api/v1/players/10101101"));
+  }
+
+  // ── helpers ──────────────────────────────────────────────────────────────
+
+  private Ranking r(
+      int dtbId,
+      String lastname,
+      String firstname,
+      String ageGroup,
+      LocalDate date,
+      int pos,
+      String club,
+      boolean ageGroupRanking) {
+    return new Ranking(
+        0L, dtbId, lastname, firstname, "GER", ageGroup, date, pos, "100", club, "TST",
+        ageGroupRanking, false, false);
+  }
+}


### PR DESCRIPTION
## Summary
- Add `GET /api/v1/clubs?name=` and `GET /api/v1/clubs/{id}` to expose the existing `/clubs` web functionality (club search and club roster) via the REST API, following `PlayersApiController` conventions (bearer auth, `ProblemDetail` errors, `request`/`data` envelopes).
- No changes to `ClubService`, `SecurityConfig`, or `RateLimitFilter` — both routes reuse existing service logic and fall under the existing `/api/v1/**` filter chain.
- Update README's API endpoint table.
- Design doc: `docs/superpowers/specs/2026-06-24-clubs-rest-api-design.md`.

## Test plan
- [x] New `ClubsApiControllerTest` (13 tests): 401 without token, 400 on missing search term, 404 on no match/unknown club, search result shape/case-insensitivity/counts, detail roster grouping/order, player item fields including `links.self`
- [x] `./mvnw test` passes
- [x] `./mvnw spotless:check pmd:check` passes