### PR TITLE
refactor: fix caching, dead code, and performance issues

### DIFF
--- a/src/main/java/de/hdawg/rankinginfo/api/v1/PlayersApiController.java
+++ b/src/main/java/de/hdawg/rankinginfo/api/v1/PlayersApiController.java
@@ -57,12 +57,18 @@ public class PlayersApiController {
                   HttpStatus.BAD_REQUEST, "lastname parameter required"));
     }
 
+    if (!yob.isBlank() && yob.length() != 4) {
+      return ResponseEntity.badRequest()
+          .body(ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, "yob must be a 4-digit year"));
+    }
+
+    int yy = yob.isBlank() ? 0 : Integer.parseInt(yob.substring(2, 4));
     var players =
         (!yob.isBlank())
             ? playerService.findPlayersByLastnameAndYob(
                 lastname,
-                Integer.parseInt(yob.substring(2, 4)) + RankingCoding.GENDER_FACTOR_JUNIOREN,
-                Integer.parseInt(yob.substring(2, 4)) + RankingCoding.GENDER_FACTOR_JUNIORINNEN)
+                yy + RankingCoding.GENDER_FACTOR_JUNIOREN,
+                yy + RankingCoding.GENDER_FACTOR_JUNIORINNEN)
             : playerService.findPlayersByLastname(lastname);
 
     if (players.isEmpty()) {

--- a/src/main/java/de/hdawg/rankinginfo/repository/RankingEntityRepository.java
+++ b/src/main/java/de/hdawg/rankinginfo/repository/RankingEntityRepository.java
@@ -113,6 +113,14 @@ interface RankingEntityRepository extends ListCrudRepository<RankingEntity, Long
       @Param("clubPattern") String clubPattern);
 
   @Query(
+      "SELECT * FROM rankings WHERE date = :date AND age_group IN (:ageGroups)"
+          + " AND LOWER(club) LIKE :clubPattern ORDER BY ranking_position ASC")
+  List<RankingEntity> findByDateAgeGroupsAndClub(
+      @Param("date") LocalDate date,
+      @Param("ageGroups") List<String> ageGroups,
+      @Param("clubPattern") String clubPattern);
+
+  @Query(
       "SELECT * FROM rankings"
           + " WHERE date = :date AND yob_ranking = false AND age_group_ranking = true"
           + " AND year_end_ranking = false AND dtb_id IN (:dtbIds)")

--- a/src/main/java/de/hdawg/rankinginfo/repository/RankingRepository.java
+++ b/src/main/java/de/hdawg/rankinginfo/repository/RankingRepository.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -121,12 +122,17 @@ public class RankingRepository {
     return jdbc.queryDistinctDatesDesc(LocalDate.now(ZoneOffset.UTC));
   }
 
+  @Nullable
+  public LocalDate findLatestDate() {
+    var dates = findDistinctDatesDesc();
+    return dates.isEmpty() ? null : dates.getFirst();
+  }
+
   @Cacheable("player_counts")
   public long countDistinctDtbIdInRange(int dtbIdStart, int dtbIdEnd) {
     return jdbc.countDistinctDtbIdInRange(dtbIdStart, dtbIdEnd);
   }
 
-  @Cacheable("federations")
   public List<String> findDistinctFederations() {
     return jdbc.queryDistinctFederations();
   }
@@ -189,6 +195,15 @@ public class RankingRepository {
       LocalDate date, String ageGroup, String club) {
     return jdbc
         .findByDateAgeGroupAndClub(date, ageGroup, "%" + club.toLowerCase(Locale.ROOT) + "%")
+        .stream()
+        .map(RankingEntity::toDomain)
+        .toList();
+  }
+
+  public List<Ranking> findByDateAndAgeGroupsAndClubContaining(
+      LocalDate date, List<String> ageGroups, String club) {
+    return jdbc
+        .findByDateAgeGroupsAndClub(date, ageGroups, "%" + club.toLowerCase(Locale.ROOT) + "%")
         .stream()
         .map(RankingEntity::toDomain)
         .toList();

--- a/src/main/java/de/hdawg/rankinginfo/web/ClubService.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/ClubService.java
@@ -1,6 +1,5 @@
 package de.hdawg.rankinginfo.web;
 
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -53,21 +52,17 @@ public class ClubService {
   /// @return matching clubs sorted by name, with youth/adult player counts; empty if no ranking
   ///     data is available yet
   public List<ClubSummary> searchClubs(String searchTerm) {
-    var quarter = rankingRepository.findDistinctDatesDesc().stream().findFirst().orElse(null);
+    var quarter = rankingRepository.findLatestDate();
     if (quarter == null) return List.of();
 
-    var youthByClub =
-        rankingRepository
-            .findByDateAndAgeGroupAndClubContaining(quarter, AGE_GROUP_OVERALL, searchTerm)
-            .stream()
-            .collect(Collectors.groupingBy(Ranking::club));
-
-    var allAdults = new ArrayList<Ranking>();
-    allAdults.addAll(
-        rankingRepository.findByDateAndAgeGroupAndClubContaining(quarter, AGE_GROUP_M00, searchTerm));
-    allAdults.addAll(
-        rankingRepository.findByDateAndAgeGroupAndClubContaining(quarter, AGE_GROUP_W00, searchTerm));
-    var adultByClub = allAdults.stream().collect(Collectors.groupingBy(Ranking::club));
+    var all = rankingRepository.findByDateAndAgeGroupsAndClubContaining(
+        quarter, List.of(AGE_GROUP_OVERALL, AGE_GROUP_M00, AGE_GROUP_W00), searchTerm);
+    var youthByClub = all.stream()
+        .filter(r -> AGE_GROUP_OVERALL.equals(r.ageGroup()))
+        .collect(Collectors.groupingBy(Ranking::club));
+    var adultByClub = all.stream()
+        .filter(r -> !AGE_GROUP_OVERALL.equals(r.ageGroup()))
+        .collect(Collectors.groupingBy(Ranking::club));
 
     return Stream.concat(youthByClub.keySet().stream(), adultByClub.keySet().stream())
         .distinct()
@@ -95,28 +90,24 @@ public class ClubService {
   /// @param clubId club name to match exactly (case-insensitive)
   /// @return rows grouped by category/age-group label; empty if no ranking data is available
   public Map<String, List<PlayerSummaryRow>> getClubDetail(String clubId) {
-    var quarter = rankingRepository.findDistinctDatesDesc().stream().findFirst().orElse(null);
+    var quarter = rankingRepository.findLatestDate();
     var players = new LinkedHashMap<String, List<PlayerSummaryRow>>();
     if (quarter == null) return players;
 
+    var all = rankingRepository.findByDateAndAgeGroupsAndClubContaining(
+        quarter, List.of(AGE_GROUP_OVERALL, AGE_GROUP_M00, AGE_GROUP_W00), clubId)
+        .stream()
+        .filter(r -> r.club().equalsIgnoreCase(clubId))
+        .toList();
+
     for (var entry : ADULT_LABELS.entrySet()) {
-      var adults =
-          rankingRepository
-              .findByDateAndAgeGroupAndClubContaining(quarter, entry.getKey(), clubId)
-              .stream()
-              .filter(r -> r.club().equalsIgnoreCase(clubId))
-              .toList();
+      var adults = all.stream().filter(r -> r.ageGroup().equals(entry.getKey())).toList();
       if (!adults.isEmpty()) {
         players.put(entry.getValue(), toPlayerSummaryRows(adults, null));
       }
     }
 
-    var youth =
-        rankingRepository
-            .findByDateAndAgeGroupAndClubContaining(quarter, AGE_GROUP_OVERALL, clubId)
-            .stream()
-            .filter(r -> r.club().equalsIgnoreCase(clubId))
-            .toList();
+    var youth = all.stream().filter(r -> AGE_GROUP_OVERALL.equals(r.ageGroup())).toList();
 
     var dtbIds = youth.stream().map(Ranking::dtbId).distinct().toList();
     if (!dtbIds.isEmpty()) {

--- a/src/main/java/de/hdawg/rankinginfo/web/FederationService.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/FederationService.java
@@ -65,7 +65,7 @@ public class FederationService {
   ///     count; empty if no ranking data is available yet
   @Cacheable("federation_stats")
   public Map<String, Map<String, Integer>> buildFederationData() {
-    var quarter = rankingRepository.findDistinctDatesDesc().stream().findFirst().orElse(null);
+    var quarter = rankingRepository.findLatestDate();
     var federations = new LinkedHashMap<String, Map<String, Integer>>();
     if (quarter == null) return federations;
 

--- a/src/main/java/de/hdawg/rankinginfo/web/PlayerProfileService.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/PlayerProfileService.java
@@ -64,9 +64,9 @@ public class PlayerProfileService {
     }
   }
 
-  @Nullable private final RankingRepository rankingRepository;
+  private final RankingRepository rankingRepository;
 
-  public PlayerProfileService(@Nullable RankingRepository rankingRepository) {
+  public PlayerProfileService(RankingRepository rankingRepository) {
     this.rankingRepository = rankingRepository;
   }
 
@@ -89,11 +89,8 @@ public class PlayerProfileService {
   /// @throws IllegalStateException if no [RankingRepository] was injected
   @Transactional(readOnly = true)
   public Optional<PlayerProfile> loadProfile(int dtbId) {
-    var repo = rankingRepository;
-    if (repo == null) throw new IllegalStateException("RankingRepository not injected");
-
     var rawRankings =
-        repo.findByDtbIdAndYobRankingFalseAndAgeGroupRankingFalseAndYearEndRankingFalseOrderByDateDescAgeGroupAsc(
+        rankingRepository.findByDtbIdAndYobRankingFalseAndAgeGroupRankingFalseAndYearEndRankingFalseOrderByDateDescAgeGroupAsc(
             dtbId);
     if (rawRankings.isEmpty()) return Optional.empty();
 
@@ -110,14 +107,14 @@ public class PlayerProfileService {
             clubs);
 
     var fullRankings =
-        repo.findByDtbIdAndYearEndRankingFalseOrderByDateAscAgeGroupAsc(dtbId);
-    var allDates = repo.findDistinctDatesDesc();
+        rankingRepository.findByDtbIdAndYearEndRankingFalseOrderByDateAscAgeGroupAsc(dtbId);
+    var allDates = rankingRepository.findDistinctDatesDesc();
     var currentQuarter = allDates.isEmpty() ? null : allDates.getFirst();
     var previousQuarter = allDates.size() > 1 ? allDates.get(1) : null;
     var recent4Dates = Set.copyOf(allDates.stream().limit(4).toList());
 
     var ageGroupRankings = currentQuarter != null
-        ? repo.findAgeGroupRankingsByDateAndDtbIds(currentQuarter, List.of(dtbId))
+        ? rankingRepository.findAgeGroupRankingsByDateAndDtbIds(currentQuarter, List.of(dtbId))
         : List.<Ranking>of();
     var currentRankings = buildCurrentRankings(dtbId, rawRankings, currentQuarter, previousQuarter, ageGroupRankings);
     var allTimeDiagram = buildDiagramData(fullRankings);
@@ -181,13 +178,16 @@ public class PlayerProfileService {
     String finalSingle = singleAgeGroup;
     String finalDouble = doubleAgeGroup;
 
+    var prevByAgeGroup = previousQuarter == null
+        ? Map.<String, Ranking>of()
+        : rawRankings.stream()
+            .filter(p -> p.date().equals(previousQuarter))
+            .collect(Collectors.toMap(Ranking::ageGroup, p -> p, (a, b) -> a));
+
     return rawRankings.stream()
         .filter(r -> r.date().equals(currentQuarter) && !AGE_GROUP_OVERALL.equals(r.ageGroup()))
         .map(r -> {
-          var prev = previousQuarter == null ? null : rawRankings.stream()
-              .filter(p -> p.date().equals(previousQuarter) && p.ageGroup().equals(r.ageGroup()))
-              .findFirst()
-              .orElse(null);
+          var prev = prevByAgeGroup.get(r.ageGroup());
           boolean isAdult = ADULT_AGE_GROUPS.contains(r.ageGroup());
           boolean isCurrent = !isAdult && r.ageGroup().equals(finalSingle);
           boolean showScore = isAdult || isCurrent;


### PR DESCRIPTION
## Summary

- **Duplicate cache annotation** — removed `@Cacheable("federations")` from `RankingRepository.findDistinctFederations()`; the cache is already applied at the `RankingService` layer, so the repository annotation caused a redundant double-write on every miss
- **Dead code in `PlayerProfileService`** — removed the `@Nullable` guard on `RankingRepository` and its unreachable null-check; Spring fails at startup if the bean is absent, so the guard was never reachable
- **O(n²) scan in `buildCurrentRankings`** — pre-grouped previous-quarter rankings into a `Map<String, Ranking>` keyed by age group before entering the stream, replacing a per-element linear scan with an O(1) map lookup
- **Triple DB queries in `ClubService`** — merged three sequential queries (overall, m00, w00) into one `IN`-clause query via a new `findByDateAndAgeGroupsAndClubContaining` method, reducing round-trips from 3 to 1 in both `searchClubs` and `getClubDetail`
- **Repeated `findDistinctDatesDesc().stream().findFirst()`** — added `RankingRepository.findLatestDate()` and used it in `ClubService` (×2) and `FederationService`
- **Unvalidated `yob` in `PlayersApiController`** — added a length check returning 400 before the `substring(2, 4)` call; also extracted the parsed value to a local variable to avoid evaluating it twice

## Test plan

- [x] `./mvnw test` passes (222 tests)
- [x] `./mvnw spotless:check pmd:check` passes