### PR TITLE
Add gRPC API mirroring the existing REST API

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<extensions>
-  <extension>
-    <groupId>org.apache.maven.extensions</groupId>
-    <artifactId>maven-build-cache-extension</artifactId>
-    <version>1.2.0</version>
-  </extension>
-</extensions>

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ COPY --from=builder /app/newrelic/newrelic.jar newrelic/newrelic.jar
 COPY newrelic/newrelic.yml newrelic/newrelic.yml
 RUN chown -R appuser:appuser app.jar newrelic/
 USER appuser
-EXPOSE 8080
+EXPOSE 8080 9090
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
   CMD wget -q --spider http://localhost:8080/actuator/health || exit 1
 ENTRYPOINT ["java", \

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The test suite uses an in-memory H2 database and the fixture CSV files in `src/t
 
 ## API
 
-All API endpoints are under `/api/v1` and require Bearer token authentication.
+All API endpoints are under `/api/v1` and require Bearer token authentication. A gRPC equivalent (`RankingService`, `PlayerService`, `ClubService`) is also available on port 9090 — see `CLAUDE.md` for details.
 
 ### Authentication
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
     build: .
     ports:
       - "8080:8080"
+      - "9090:9090"
     environment:
       SPRING_PROFILES_ACTIVE: prod
       DB_HOST: postgres
@@ -36,7 +37,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 1280m
+          memory: 1536m
           cpus: "1.0"
     restart: unless-stopped
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
     <protobuf.version>4.29.3</protobuf.version>
     <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
     <os-maven-plugin.version>1.7.1</os-maven-plugin.version>
+    <javax-annotation-api.version>1.3.2</javax-annotation-api.version>
 
     <!-- Plugin versions -->
     <maven-enforcer-plugin.version>3.6.3</maven-enforcer-plugin.version>
@@ -152,6 +153,14 @@
       <groupId>io.grpc</groupId>
       <artifactId>grpc-services</artifactId>
       <version>${grpc.version}</version>
+    </dependency>
+    <!-- Required at compile time only: grpc-java's protoc plugin annotates generated service
+         stubs with @javax.annotation.Generated, a package removed from the JDK in Java 9+. -->
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <version>${javax-annotation-api.version}</version>
+      <scope>provided</scope>
     </dependency>
 
     <!-- Test -->

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,11 @@
     <opencsv.version>5.12.0</opencsv.version>
     <springdoc-openapi.version>3.0.3</springdoc-openapi.version>
     <bucket4j.version>8.19.0</bucket4j.version>
+    <grpc-spring-boot-starter.version>3.1.0.RELEASE</grpc-spring-boot-starter.version>
+    <grpc.version>1.71.0</grpc.version>
+    <protobuf.version>4.29.3</protobuf.version>
+    <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
+    <os-maven-plugin.version>1.7.1</os-maven-plugin.version>
 
     <!-- Plugin versions -->
     <maven-enforcer-plugin.version>3.6.3</maven-enforcer-plugin.version>
@@ -42,6 +47,21 @@
       ${project.build.directory}/site/jacoco/jacoco.xml
     </sonar.coverage.jacoco.xmlReportPaths>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <!-- Pin io.grpc:* to grpc.version: Spring Boot 4.1.0's parent BOM otherwise
+           manages io.grpc artifacts to a different version (1.80.0), causing a
+           conflict with grpc-server-spring-boot-starter's expected line (1.71.0). -->
+      <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-bom</artifactId>
+        <version>${grpc.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <!-- Web / jte -->
@@ -122,6 +142,18 @@
       <version>${bucket4j.version}</version>
     </dependency>
 
+    <!-- gRPC -->
+    <dependency>
+      <groupId>net.devh</groupId>
+      <artifactId>grpc-server-spring-boot-starter</artifactId>
+      <version>${grpc-spring-boot-starter.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-services</artifactId>
+      <version>${grpc.version}</version>
+    </dependency>
+
     <!-- Test -->
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -142,6 +174,13 @@
   </dependencies>
 
   <build>
+    <extensions>
+      <extension>
+        <groupId>kr.motd.maven</groupId>
+        <artifactId>os-maven-plugin</artifactId>
+        <version>${os-maven-plugin.version}</version>
+      </extension>
+    </extensions>
     <plugins>
 
       <!-- Enforcer: require Maven 3.9.16+ and Java 25 -->
@@ -173,6 +212,26 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+
+      <!-- Protobuf/gRPC codegen: runs in generate-sources, before jte-maven-plugin -->
+      <plugin>
+        <groupId>org.xolstice.maven.plugins</groupId>
+        <artifactId>protobuf-maven-plugin</artifactId>
+        <version>${protobuf-maven-plugin.version}</version>
+        <configuration>
+          <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
+          <pluginId>grpc-java</pluginId>
+          <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>compile</goal>
+              <goal>compile-custom</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
 
       <!-- jte: precompile templates into the JAR for production -->
@@ -262,6 +321,9 @@
             <ruleset>category/java/errorprone.xml</ruleset>
           </rulesets>
           <printFailingErrors>true</printFailingErrors>
+          <excludes>
+            <exclude>**/grpc/v1/*.java</exclude>
+          </excludes>
         </configuration>
         <executions>
           <execution>

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -43,4 +43,9 @@
     <Field name="updatedAt"/>
   </Match>
 
+  <!-- Generated protobuf/gRPC stub code -->
+  <Match>
+    <Package name="de.hdawg.rankinginfo.grpc.v1"/>
+  </Match>
+
 </FindBugsFilter>

--- a/src/main/java/de/hdawg/rankinginfo/api/security/ApiTokenValidator.java
+++ b/src/main/java/de/hdawg/rankinginfo/api/security/ApiTokenValidator.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 import de.hdawg.rankinginfo.config.ApiProperties;
 
 @Component
-public class ApiTokenValidator {
+public final class ApiTokenValidator {
 
   private final Set<String> validTokens;
 

--- a/src/main/java/de/hdawg/rankinginfo/api/security/ApiTokenValidator.java
+++ b/src/main/java/de/hdawg/rankinginfo/api/security/ApiTokenValidator.java
@@ -1,0 +1,37 @@
+package de.hdawg.rankinginfo.api.security;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.springframework.stereotype.Component;
+
+import de.hdawg.rankinginfo.config.ApiProperties;
+
+@Component
+public class ApiTokenValidator {
+
+  private final Set<String> validTokens;
+
+  public ApiTokenValidator(ApiProperties apiProperties) {
+    var tokens = new HashSet<String>();
+    apiProperties.tokens().stream().filter(t -> !t.isBlank()).forEach(tokens::add);
+    var env = System.getenv("API_BEARER_TOKEN");
+    if (env != null && !env.isBlank()) {
+      tokens.add(env);
+    }
+    this.validTokens = Set.copyOf(tokens);
+  }
+
+  public boolean isValid(String token) {
+    var tokenBytes = token.getBytes(StandardCharsets.UTF_8);
+    boolean valid = false;
+    for (var t : validTokens) {
+      if (MessageDigest.isEqual(tokenBytes, t.getBytes(StandardCharsets.UTF_8))) {
+        valid = true;
+      }
+    }
+    return valid;
+  }
+}

--- a/src/main/java/de/hdawg/rankinginfo/api/security/BearerTokenFilter.java
+++ b/src/main/java/de/hdawg/rankinginfo/api/security/BearerTokenFilter.java
@@ -1,12 +1,7 @@
 package de.hdawg.rankinginfo.api.security;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -19,18 +14,12 @@ import tools.jackson.databind.ObjectMapper;
 
 public final class BearerTokenFilter extends OncePerRequestFilter {
 
-  private final Set<String> validTokens;
+  private final ApiTokenValidator tokenValidator;
   private final ObjectMapper objectMapper;
 
-  public BearerTokenFilter(List<String> configuredTokens, ObjectMapper objectMapper) {
+  public BearerTokenFilter(ApiTokenValidator tokenValidator, ObjectMapper objectMapper) {
+    this.tokenValidator = tokenValidator;
     this.objectMapper = objectMapper;
-    var tokens = new HashSet<String>();
-    configuredTokens.stream().filter(t -> !t.isBlank()).forEach(tokens::add);
-    var env = System.getenv("API_BEARER_TOKEN");
-    if (env != null && !env.isBlank()) {
-      tokens.add(env);
-    }
-    this.validTokens = Set.copyOf(tokens);
   }
 
   @Override
@@ -39,23 +28,12 @@ public final class BearerTokenFilter extends OncePerRequestFilter {
       throws ServletException, IOException {
     var authHeader = request.getHeader("Authorization");
     var token = authHeader != null ? authHeader.replaceFirst("^Bearer ", "") : null;
-    if (token == null || token.isBlank() || !isValidToken(token)) {
+    if (token == null || token.isBlank() || !tokenValidator.isValid(token)) {
       response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
       response.setContentType(MediaType.APPLICATION_JSON_VALUE);
       objectMapper.writeValue(response.getWriter(), Map.of("error", "Unauthorized"));
       return;
     }
     filterChain.doFilter(request, response);
-  }
-
-  private boolean isValidToken(String token) {
-    var tokenBytes = token.getBytes(StandardCharsets.UTF_8);
-    boolean valid = false;
-    for (var t : validTokens) {
-      if (MessageDigest.isEqual(tokenBytes, t.getBytes(StandardCharsets.UTF_8))) {
-        valid = true;
-      }
-    }
-    return valid;
   }
 }

--- a/src/main/java/de/hdawg/rankinginfo/api/security/RateLimitFilter.java
+++ b/src/main/java/de/hdawg/rankinginfo/api/security/RateLimitFilter.java
@@ -1,7 +1,6 @@
 package de.hdawg.rankinginfo.api.security;
 
 import java.io.IOException;
-import java.time.Duration;
 import java.util.Map;
 
 import jakarta.servlet.FilterChain;
@@ -9,10 +8,6 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
-import io.github.bucket4j.Bandwidth;
-import io.github.bucket4j.Bucket;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -20,11 +15,11 @@ import tools.jackson.databind.ObjectMapper;
 
 public class RateLimitFilter extends OncePerRequestFilter {
 
+  private final RequestRateLimiter rateLimiter;
   private final ObjectMapper objectMapper;
-  private final Cache<String, Bucket> buckets =
-      Caffeine.newBuilder().expireAfterAccess(Duration.ofHours(2)).build();
 
-  public RateLimitFilter(ObjectMapper objectMapper) {
+  public RateLimitFilter(RequestRateLimiter rateLimiter, ObjectMapper objectMapper) {
+    this.rateLimiter = rateLimiter;
     this.objectMapper = objectMapper;
   }
 
@@ -39,21 +34,13 @@ public class RateLimitFilter extends OncePerRequestFilter {
       throws ServletException, IOException {
     var auth = request.getHeader("Authorization");
     var key = auth != null ? auth : request.getRemoteAddr();
-    var bucket = buckets.get(key, k -> createBucket());
 
-    if (bucket.tryConsume(1)) {
+    if (rateLimiter.tryConsume(key)) {
       filterChain.doFilter(request, response);
     } else {
       response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
       response.setContentType(MediaType.APPLICATION_JSON_VALUE);
       objectMapper.writeValue(response.getWriter(), Map.of("error", "Too Many Requests"));
     }
-  }
-
-  private static Bucket createBucket() {
-    return Bucket.builder()
-        .addLimit(
-            Bandwidth.builder().capacity(1000).refillGreedy(1000, Duration.ofHours(1)).build())
-        .build();
   }
 }

--- a/src/main/java/de/hdawg/rankinginfo/api/security/RequestRateLimiter.java
+++ b/src/main/java/de/hdawg/rankinginfo/api/security/RequestRateLimiter.java
@@ -1,0 +1,28 @@
+package de.hdawg.rankinginfo.api.security;
+
+import java.time.Duration;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RequestRateLimiter {
+
+  private final Cache<String, Bucket> buckets =
+      Caffeine.newBuilder().expireAfterAccess(Duration.ofHours(2)).build();
+
+  public boolean tryConsume(String key) {
+    var bucket = buckets.get(key, k -> createBucket());
+    return bucket.tryConsume(1);
+  }
+
+  private static Bucket createBucket() {
+    return Bucket.builder()
+        .addLimit(
+            Bandwidth.builder().capacity(1000).refillGreedy(1000, Duration.ofHours(1)).build())
+        .build();
+  }
+}

--- a/src/main/java/de/hdawg/rankinginfo/config/SecurityConfig.java
+++ b/src/main/java/de/hdawg/rankinginfo/config/SecurityConfig.java
@@ -14,6 +14,7 @@ import tools.jackson.databind.ObjectMapper;
 import de.hdawg.rankinginfo.api.security.ApiTokenValidator;
 import de.hdawg.rankinginfo.api.security.BearerTokenFilter;
 import de.hdawg.rankinginfo.api.security.RateLimitFilter;
+import de.hdawg.rankinginfo.api.security.RequestRateLimiter;
 
 @Configuration
 @EnableWebSecurity
@@ -23,9 +24,12 @@ public class SecurityConfig {
   @Bean
   @Order(1)
   public SecurityFilterChain apiSecurityFilterChain(
-      HttpSecurity http, ApiTokenValidator tokenValidator, ObjectMapper objectMapper)
+      HttpSecurity http,
+      RequestRateLimiter requestRateLimiter,
+      ApiTokenValidator tokenValidator,
+      ObjectMapper objectMapper)
       throws Exception {
-    var rateLimitFilter = new RateLimitFilter(objectMapper);
+    var rateLimitFilter = new RateLimitFilter(requestRateLimiter, objectMapper);
     var bearerFilter = new BearerTokenFilter(tokenValidator, objectMapper);
 
     return http.securityMatcher("/api/v1/**")

--- a/src/main/java/de/hdawg/rankinginfo/config/SecurityConfig.java
+++ b/src/main/java/de/hdawg/rankinginfo/config/SecurityConfig.java
@@ -11,6 +11,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import tools.jackson.databind.ObjectMapper;
 
+import de.hdawg.rankinginfo.api.security.ApiTokenValidator;
 import de.hdawg.rankinginfo.api.security.BearerTokenFilter;
 import de.hdawg.rankinginfo.api.security.RateLimitFilter;
 
@@ -22,9 +23,10 @@ public class SecurityConfig {
   @Bean
   @Order(1)
   public SecurityFilterChain apiSecurityFilterChain(
-      HttpSecurity http, ApiProperties apiProperties, ObjectMapper objectMapper) throws Exception {
+      HttpSecurity http, ApiTokenValidator tokenValidator, ObjectMapper objectMapper)
+      throws Exception {
     var rateLimitFilter = new RateLimitFilter(objectMapper);
-    var bearerFilter = new BearerTokenFilter(apiProperties.tokens(), objectMapper);
+    var bearerFilter = new BearerTokenFilter(tokenValidator, objectMapper);
 
     return http.securityMatcher("/api/v1/**")
         .csrf(AbstractHttpConfigurer::disable)

--- a/src/main/java/de/hdawg/rankinginfo/grpc/ClubGrpcService.java
+++ b/src/main/java/de/hdawg/rankinginfo/grpc/ClubGrpcService.java
@@ -1,0 +1,91 @@
+package de.hdawg.rankinginfo.grpc;
+
+import java.util.NoSuchElementException;
+
+import io.grpc.stub.StreamObserver;
+import net.devh.boot.grpc.server.service.GrpcService;
+
+import de.hdawg.rankinginfo.grpc.v1.ClubGroup;
+import de.hdawg.rankinginfo.grpc.v1.ClubPlayerItem;
+import de.hdawg.rankinginfo.grpc.v1.ClubSearchItem;
+import de.hdawg.rankinginfo.grpc.v1.ClubServiceGrpc;
+import de.hdawg.rankinginfo.grpc.v1.GetClubRequest;
+import de.hdawg.rankinginfo.grpc.v1.GetClubResponse;
+import de.hdawg.rankinginfo.grpc.v1.SearchClubsRequest;
+import de.hdawg.rankinginfo.grpc.v1.SearchClubsResponse;
+import de.hdawg.rankinginfo.web.ClubService;
+
+@GrpcService
+public class ClubGrpcService extends ClubServiceGrpc.ClubServiceImplBase {
+
+  private final ClubService clubService;
+
+  public ClubGrpcService(ClubService clubService) {
+    this.clubService = clubService;
+  }
+
+  @Override
+  public void searchClubs(
+      SearchClubsRequest request, StreamObserver<SearchClubsResponse> responseObserver) {
+    if (request.getName().isBlank()) {
+      throw new IllegalArgumentException("name parameter required");
+    }
+
+    var clubs = clubService.searchClubs(request.getName());
+    if (clubs.isEmpty()) {
+      throw new NoSuchElementException("Not Found");
+    }
+
+    var items =
+        clubs.stream()
+            .map(
+                c ->
+                    ClubSearchItem.newBuilder()
+                        .setName(c.name())
+                        .setYouthCount(c.youthCount())
+                        .setAdultCount(c.adultCount())
+                        .build())
+            .toList();
+
+    responseObserver.onNext(
+        SearchClubsResponse.newBuilder()
+            .setRequest(request)
+            .addAllItems(items)
+            .setTotalCount(clubs.size())
+            .build());
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  public void getClub(GetClubRequest request, StreamObserver<GetClubResponse> responseObserver) {
+    var roster = clubService.getClubDetail(request.getId());
+    if (roster.isEmpty()) {
+      throw new NoSuchElementException("Not Found");
+    }
+
+    var groups =
+        roster.entrySet().stream()
+            .map(
+                e ->
+                    ClubGroup.newBuilder()
+                        .setGroup(e.getKey())
+                        .addAllPlayers(
+                            e.getValue().stream()
+                                .map(
+                                    p ->
+                                        ClubPlayerItem.newBuilder()
+                                            .setDtbId(p.dtbId())
+                                            .setLastname(p.lastname())
+                                            .setFirstname(p.firstname())
+                                            .setRank(p.rank())
+                                            .setScore(p.score())
+                                            .build())
+                                .toList())
+                        .build())
+            .toList();
+
+    responseObserver.onNext(
+        GetClubResponse.newBuilder().setName(request.getId()).addAllGroups(groups).build());
+    responseObserver.onCompleted();
+  }
+}

--- a/src/main/java/de/hdawg/rankinginfo/grpc/GrpcAuthInterceptor.java
+++ b/src/main/java/de/hdawg/rankinginfo/grpc/GrpcAuthInterceptor.java
@@ -1,7 +1,5 @@
 package de.hdawg.rankinginfo.grpc;
 
-import java.util.Set;
-
 import io.grpc.Metadata;
 import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
@@ -21,9 +19,6 @@ public class GrpcAuthInterceptor implements ServerInterceptor {
   static final Metadata.Key<String> AUTHORIZATION_KEY =
       Metadata.Key.of("authorization", Metadata.ASCII_STRING_MARSHALLER);
 
-  private static final Set<String> PUBLIC_SERVICES =
-      Set.of("grpc.health.v1.Health", "grpc.reflection.v1alpha.ServerReflection", "grpc.reflection.v1.ServerReflection");
-
   private final ApiTokenValidator tokenValidator;
 
   public GrpcAuthInterceptor(ApiTokenValidator tokenValidator) {
@@ -33,7 +28,7 @@ public class GrpcAuthInterceptor implements ServerInterceptor {
   @Override
   public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
       ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
-    if (PUBLIC_SERVICES.contains(call.getMethodDescriptor().getServiceName())) {
+    if (GrpcPublicServices.NAMES.contains(call.getMethodDescriptor().getServiceName())) {
       return next.startCall(call, headers);
     }
 

--- a/src/main/java/de/hdawg/rankinginfo/grpc/GrpcAuthInterceptor.java
+++ b/src/main/java/de/hdawg/rankinginfo/grpc/GrpcAuthInterceptor.java
@@ -1,0 +1,48 @@
+package de.hdawg.rankinginfo.grpc;
+
+import java.util.Set;
+
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.Status;
+import net.devh.boot.grpc.server.interceptor.GrpcGlobalServerInterceptor;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import de.hdawg.rankinginfo.api.security.ApiTokenValidator;
+
+@Component
+@GrpcGlobalServerInterceptor
+@Order(2)
+public class GrpcAuthInterceptor implements ServerInterceptor {
+
+  static final Metadata.Key<String> AUTHORIZATION_KEY =
+      Metadata.Key.of("authorization", Metadata.ASCII_STRING_MARSHALLER);
+
+  private static final Set<String> PUBLIC_SERVICES =
+      Set.of("grpc.health.v1.Health", "grpc.reflection.v1alpha.ServerReflection", "grpc.reflection.v1.ServerReflection");
+
+  private final ApiTokenValidator tokenValidator;
+
+  public GrpcAuthInterceptor(ApiTokenValidator tokenValidator) {
+    this.tokenValidator = tokenValidator;
+  }
+
+  @Override
+  public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+      ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+    if (PUBLIC_SERVICES.contains(call.getMethodDescriptor().getServiceName())) {
+      return next.startCall(call, headers);
+    }
+
+    var authHeader = headers.get(AUTHORIZATION_KEY);
+    var token = authHeader != null ? authHeader.replaceFirst("^Bearer ", "") : null;
+    if (token == null || token.isBlank() || !tokenValidator.isValid(token)) {
+      call.close(Status.UNAUTHENTICATED.withDescription("Unauthorized"), new Metadata());
+      return new ServerCall.Listener<>() {};
+    }
+    return next.startCall(call, headers);
+  }
+}

--- a/src/main/java/de/hdawg/rankinginfo/grpc/GrpcExceptionAdvice.java
+++ b/src/main/java/de/hdawg/rankinginfo/grpc/GrpcExceptionAdvice.java
@@ -1,0 +1,26 @@
+package de.hdawg.rankinginfo.grpc;
+
+import java.util.NoSuchElementException;
+
+import io.grpc.Status;
+import net.devh.boot.grpc.server.advice.GrpcAdvice;
+import net.devh.boot.grpc.server.advice.GrpcExceptionHandler;
+
+@GrpcAdvice
+public class GrpcExceptionAdvice {
+
+  @GrpcExceptionHandler({NoSuchElementException.class, IndexOutOfBoundsException.class})
+  public Status handleNotFound(Exception e) {
+    return Status.NOT_FOUND.withDescription("Not Found");
+  }
+
+  @GrpcExceptionHandler(IllegalArgumentException.class)
+  public Status handleIllegalArgument(IllegalArgumentException e) {
+    return Status.INVALID_ARGUMENT.withDescription(e.getMessage());
+  }
+
+  @GrpcExceptionHandler(Exception.class)
+  public Status handleException(Exception e) {
+    return Status.INTERNAL.withDescription("Internal Server Error");
+  }
+}

--- a/src/main/java/de/hdawg/rankinginfo/grpc/GrpcExceptionAdvice.java
+++ b/src/main/java/de/hdawg/rankinginfo/grpc/GrpcExceptionAdvice.java
@@ -19,6 +19,10 @@ public class GrpcExceptionAdvice {
     return Status.INVALID_ARGUMENT.withDescription(e.getMessage());
   }
 
+  // Catch-all: intercepts EVERYTHING, including an already-built StatusRuntimeException from a
+  // direct Status.xxx.asRuntimeException() throw, and downgrades it to INTERNAL. gRPC service
+  // implementations must throw plain domain exceptions (IllegalArgumentException,
+  // NoSuchElementException, etc.) instead, or this handler will swallow their real status code.
   @GrpcExceptionHandler(Exception.class)
   public Status handleException(Exception e) {
     return Status.INTERNAL.withDescription("Internal Server Error");

--- a/src/main/java/de/hdawg/rankinginfo/grpc/GrpcPublicServices.java
+++ b/src/main/java/de/hdawg/rankinginfo/grpc/GrpcPublicServices.java
@@ -1,0 +1,11 @@
+package de.hdawg.rankinginfo.grpc;
+
+import java.util.Set;
+
+final class GrpcPublicServices {
+
+  static final Set<String> NAMES =
+      Set.of("grpc.health.v1.Health", "grpc.reflection.v1alpha.ServerReflection", "grpc.reflection.v1.ServerReflection");
+
+  private GrpcPublicServices() {}
+}

--- a/src/main/java/de/hdawg/rankinginfo/grpc/GrpcRateLimitInterceptor.java
+++ b/src/main/java/de/hdawg/rankinginfo/grpc/GrpcRateLimitInterceptor.java
@@ -1,0 +1,48 @@
+package de.hdawg.rankinginfo.grpc;
+
+import java.util.Set;
+
+import io.grpc.Grpc;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.Status;
+import net.devh.boot.grpc.server.interceptor.GrpcGlobalServerInterceptor;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import de.hdawg.rankinginfo.api.security.RequestRateLimiter;
+
+@Component
+@GrpcGlobalServerInterceptor
+@Order(1)
+public class GrpcRateLimitInterceptor implements ServerInterceptor {
+
+  private static final Set<String> PUBLIC_SERVICES =
+      Set.of("grpc.health.v1.Health", "grpc.reflection.v1alpha.ServerReflection", "grpc.reflection.v1.ServerReflection");
+
+  private final RequestRateLimiter rateLimiter;
+
+  public GrpcRateLimitInterceptor(RequestRateLimiter rateLimiter) {
+    this.rateLimiter = rateLimiter;
+  }
+
+  @Override
+  public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+      ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+    if (PUBLIC_SERVICES.contains(call.getMethodDescriptor().getServiceName())) {
+      return next.startCall(call, headers);
+    }
+
+    var authHeader = headers.get(GrpcAuthInterceptor.AUTHORIZATION_KEY);
+    var remoteAddr = call.getAttributes().get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR);
+    var key = authHeader != null ? authHeader : String.valueOf(remoteAddr);
+
+    if (rateLimiter.tryConsume(key)) {
+      return next.startCall(call, headers);
+    }
+    call.close(Status.RESOURCE_EXHAUSTED.withDescription("Too Many Requests"), new Metadata());
+    return new ServerCall.Listener<>() {};
+  }
+}

--- a/src/main/java/de/hdawg/rankinginfo/grpc/GrpcRateLimitInterceptor.java
+++ b/src/main/java/de/hdawg/rankinginfo/grpc/GrpcRateLimitInterceptor.java
@@ -1,7 +1,6 @@
 package de.hdawg.rankinginfo.grpc;
 
 import java.net.InetSocketAddress;
-import java.util.Set;
 
 import io.grpc.Grpc;
 import io.grpc.Metadata;
@@ -20,9 +19,6 @@ import de.hdawg.rankinginfo.api.security.RequestRateLimiter;
 @Order(1)
 public class GrpcRateLimitInterceptor implements ServerInterceptor {
 
-  private static final Set<String> PUBLIC_SERVICES =
-      Set.of("grpc.health.v1.Health", "grpc.reflection.v1alpha.ServerReflection", "grpc.reflection.v1.ServerReflection");
-
   private final RequestRateLimiter rateLimiter;
 
   public GrpcRateLimitInterceptor(RequestRateLimiter rateLimiter) {
@@ -32,7 +28,7 @@ public class GrpcRateLimitInterceptor implements ServerInterceptor {
   @Override
   public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
       ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
-    if (PUBLIC_SERVICES.contains(call.getMethodDescriptor().getServiceName())) {
+    if (GrpcPublicServices.NAMES.contains(call.getMethodDescriptor().getServiceName())) {
       return next.startCall(call, headers);
     }
 

--- a/src/main/java/de/hdawg/rankinginfo/grpc/GrpcRateLimitInterceptor.java
+++ b/src/main/java/de/hdawg/rankinginfo/grpc/GrpcRateLimitInterceptor.java
@@ -1,5 +1,6 @@
 package de.hdawg.rankinginfo.grpc;
 
+import java.net.InetSocketAddress;
 import java.util.Set;
 
 import io.grpc.Grpc;
@@ -37,7 +38,12 @@ public class GrpcRateLimitInterceptor implements ServerInterceptor {
 
     var authHeader = headers.get(GrpcAuthInterceptor.AUTHORIZATION_KEY);
     var remoteAddr = call.getAttributes().get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR);
-    var key = authHeader != null ? authHeader : String.valueOf(remoteAddr);
+    var key =
+        authHeader != null
+            ? authHeader
+            : remoteAddr instanceof InetSocketAddress inetAddr
+                ? inetAddr.getAddress().getHostAddress()
+                : String.valueOf(remoteAddr);
 
     if (rateLimiter.tryConsume(key)) {
       return next.startCall(call, headers);

--- a/src/main/java/de/hdawg/rankinginfo/grpc/PlayerGrpcService.java
+++ b/src/main/java/de/hdawg/rankinginfo/grpc/PlayerGrpcService.java
@@ -1,0 +1,103 @@
+package de.hdawg.rankinginfo.grpc;
+
+import java.util.NoSuchElementException;
+
+import io.grpc.stub.StreamObserver;
+import net.devh.boot.grpc.server.service.GrpcService;
+
+import de.hdawg.rankinginfo.domain.RankingCoding;
+import de.hdawg.rankinginfo.grpc.v1.GetPlayerRequest;
+import de.hdawg.rankinginfo.grpc.v1.GetPlayerResponse;
+import de.hdawg.rankinginfo.grpc.v1.PlayerRankingEntry;
+import de.hdawg.rankinginfo.grpc.v1.PlayerSearchItem;
+import de.hdawg.rankinginfo.grpc.v1.PlayerServiceGrpc;
+import de.hdawg.rankinginfo.grpc.v1.SearchPlayersRequest;
+import de.hdawg.rankinginfo.grpc.v1.SearchPlayersResponse;
+import de.hdawg.rankinginfo.service.PlayerService;
+
+@GrpcService
+public class PlayerGrpcService extends PlayerServiceGrpc.PlayerServiceImplBase {
+
+  private final PlayerService playerService;
+
+  public PlayerGrpcService(PlayerService playerService) {
+    this.playerService = playerService;
+  }
+
+  @Override
+  public void searchPlayers(
+      SearchPlayersRequest request, StreamObserver<SearchPlayersResponse> responseObserver) {
+    if (request.getLastname().isBlank()) {
+      throw new IllegalArgumentException("lastname parameter required");
+    }
+    var yob = request.getYob();
+    if (!yob.isBlank() && yob.length() != 4) {
+      throw new IllegalArgumentException("yob must be a 4-digit year");
+    }
+
+    int yy = yob.isBlank() ? 0 : Integer.parseInt(yob.substring(2, 4));
+    var players =
+        !yob.isBlank()
+            ? playerService.findPlayersByLastnameAndYob(
+                request.getLastname(),
+                yy + RankingCoding.GENDER_FACTOR_JUNIOREN,
+                yy + RankingCoding.GENDER_FACTOR_JUNIORINNEN)
+            : playerService.findPlayersByLastname(request.getLastname());
+
+    if (players.isEmpty()) {
+      throw new NoSuchElementException("Not Found");
+    }
+
+    var items =
+        players.stream()
+            .map(
+                p ->
+                    PlayerSearchItem.newBuilder()
+                        .setDtbId(p.dtbId())
+                        .setLastname(p.lastname())
+                        .setFirstname(p.firstname())
+                        .setClub(p.club())
+                        .build())
+            .toList();
+
+    responseObserver.onNext(
+        SearchPlayersResponse.newBuilder()
+            .setRequest(request)
+            .addAllItems(items)
+            .setTotalCount(players.size())
+            .build());
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  public void getPlayer(GetPlayerRequest request, StreamObserver<GetPlayerResponse> responseObserver) {
+    var rankings = playerService.findNonAggregateRankings(request.getDtbId());
+    if (rankings.isEmpty()) {
+      throw new NoSuchElementException("Not Found");
+    }
+    var current = rankings.getFirst();
+    var entries =
+        rankings.stream()
+            .map(
+                r ->
+                    PlayerRankingEntry.newBuilder()
+                        .setQuarter(r.date().toString())
+                        .setAgeGroup(r.ageGroup())
+                        .setRankingPosition(r.rankingPosition())
+                        .setScore(r.score())
+                        .build())
+            .toList();
+
+    responseObserver.onNext(
+        GetPlayerResponse.newBuilder()
+            .setDtbId(current.dtbId())
+            .setLastname(current.lastname())
+            .setFirstname(current.firstname())
+            .setNationality(current.nationality())
+            .setClub(current.club())
+            .setFederation(current.federation())
+            .addAllRankings(entries)
+            .build());
+    responseObserver.onCompleted();
+  }
+}

--- a/src/main/java/de/hdawg/rankinginfo/grpc/RankingGrpcService.java
+++ b/src/main/java/de/hdawg/rankinginfo/grpc/RankingGrpcService.java
@@ -26,7 +26,8 @@ public class RankingGrpcService extends RankingServiceGrpc.RankingServiceImplBas
   @Override
   public void listListings(
       ListListingsRequest request, StreamObserver<ListListingsResponse> responseObserver) {
-    var cappedPerPage = Math.min(request.getPerPage(), MAX_PER_PAGE);
+    var page = request.getPage() < 1 ? 1 : request.getPage();
+    var cappedPerPage = request.getPerPage() < 1 ? 25 : Math.min(request.getPerPage(), MAX_PER_PAGE);
     var filter =
         new RankingFilter(
             request.getQuarter(),
@@ -36,7 +37,7 @@ public class RankingGrpcService extends RankingServiceGrpc.RankingServiceImplBas
             request.getClub().isBlank() ? null : request.getClub(),
             request.getYearEnd());
 
-    var rankings = rankingService.findFilteredRankings(filter, request.getPage(), cappedPerPage);
+    var rankings = rankingService.findFilteredRankings(filter, page, cappedPerPage);
     var dtbIds = rankings.getContent().stream().map(Ranking::dtbId).toList();
     var prevPositions = rankingService.findPreviousPositions(filter, dtbIds);
 
@@ -50,7 +51,7 @@ public class RankingGrpcService extends RankingServiceGrpc.RankingServiceImplBas
             .setFederation(request.getFederation())
             .setClub(request.getClub())
             .setYearEnd(request.getYearEnd())
-            .setPage(request.getPage())
+            .setPage(page)
             .setPerPage(cappedPerPage)
             .build();
 
@@ -60,7 +61,7 @@ public class RankingGrpcService extends RankingServiceGrpc.RankingServiceImplBas
             .addAllItems(items)
             .setPageInfo(
                 PageInfo.newBuilder()
-                    .setPage(request.getPage())
+                    .setPage(page)
                     .setPerPage(cappedPerPage)
                     .setTotalCount(rankings.getTotalElements())
                     .build())

--- a/src/main/java/de/hdawg/rankinginfo/grpc/RankingGrpcService.java
+++ b/src/main/java/de/hdawg/rankinginfo/grpc/RankingGrpcService.java
@@ -1,0 +1,89 @@
+package de.hdawg.rankinginfo.grpc;
+
+import io.grpc.stub.StreamObserver;
+import net.devh.boot.grpc.server.service.GrpcService;
+
+import de.hdawg.rankinginfo.domain.Ranking;
+import de.hdawg.rankinginfo.grpc.v1.ListListingsRequest;
+import de.hdawg.rankinginfo.grpc.v1.ListListingsResponse;
+import de.hdawg.rankinginfo.grpc.v1.ListingItem;
+import de.hdawg.rankinginfo.grpc.v1.PageInfo;
+import de.hdawg.rankinginfo.grpc.v1.RankingServiceGrpc;
+import de.hdawg.rankinginfo.service.RankingFilter;
+import de.hdawg.rankinginfo.service.RankingService;
+
+@GrpcService
+public class RankingGrpcService extends RankingServiceGrpc.RankingServiceImplBase {
+
+  private static final int MAX_PER_PAGE = 100;
+
+  private final RankingService rankingService;
+
+  public RankingGrpcService(RankingService rankingService) {
+    this.rankingService = rankingService;
+  }
+
+  @Override
+  public void listListings(
+      ListListingsRequest request, StreamObserver<ListListingsResponse> responseObserver) {
+    var cappedPerPage = Math.min(request.getPerPage(), MAX_PER_PAGE);
+    var filter =
+        new RankingFilter(
+            request.getQuarter(),
+            request.getAgeGroupSlug(),
+            request.getAgeGroupOptions().isBlank() ? null : request.getAgeGroupOptions(),
+            request.getFederation().isBlank() ? null : request.getFederation(),
+            request.getClub().isBlank() ? null : request.getClub(),
+            request.getYearEnd());
+
+    var rankings = rankingService.findFilteredRankings(filter, request.getPage(), cappedPerPage);
+    var dtbIds = rankings.getContent().stream().map(Ranking::dtbId).toList();
+    var prevPositions = rankingService.findPreviousPositions(filter, dtbIds);
+
+    var items = rankings.getContent().stream().map(r -> toListingItem(r, prevPositions.get(r.dtbId()))).toList();
+
+    var echo =
+        ListListingsRequest.newBuilder()
+            .setQuarter(request.getQuarter())
+            .setAgeGroupSlug(request.getAgeGroupSlug())
+            .setAgeGroupOptions(request.getAgeGroupOptions())
+            .setFederation(request.getFederation())
+            .setClub(request.getClub())
+            .setYearEnd(request.getYearEnd())
+            .setPage(request.getPage())
+            .setPerPage(cappedPerPage)
+            .build();
+
+    var response =
+        ListListingsResponse.newBuilder()
+            .setRequest(echo)
+            .addAllItems(items)
+            .setPageInfo(
+                PageInfo.newBuilder()
+                    .setPage(request.getPage())
+                    .setPerPage(cappedPerPage)
+                    .setTotalCount(rankings.getTotalElements())
+                    .build())
+            .build();
+
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
+  }
+
+  private static ListingItem toListingItem(Ranking r, Integer prevPosition) {
+    var builder =
+        ListingItem.newBuilder()
+            .setDtbId(r.dtbId())
+            .setRankingPosition(r.rankingPosition())
+            .setLastname(r.lastname())
+            .setFirstname(r.firstname())
+            .setNationality(r.nationality())
+            .setClub(r.club())
+            .setFederation(r.federation())
+            .setScore(r.score());
+    if (prevPosition != null) {
+      builder.setPositionChange(prevPosition - r.rankingPosition());
+    }
+    return builder.build();
+  }
+}

--- a/src/main/proto/club.proto
+++ b/src/main/proto/club.proto
@@ -1,0 +1,49 @@
+syntax = "proto3";
+
+package rankinginfo.v1;
+
+option java_package = "de.hdawg.rankinginfo.grpc.v1";
+option java_multiple_files = true;
+
+service ClubService {
+  rpc SearchClubs(SearchClubsRequest) returns (SearchClubsResponse);
+  rpc GetClub(GetClubRequest) returns (GetClubResponse);
+}
+
+message SearchClubsRequest {
+  string name = 1;
+}
+
+message SearchClubsResponse {
+  SearchClubsRequest request = 1;
+  repeated ClubSearchItem items = 2;
+  int32 total_count = 3;
+}
+
+message ClubSearchItem {
+  string name = 1;
+  int32 youth_count = 2;
+  int32 adult_count = 3;
+}
+
+message GetClubRequest {
+  string id = 1;
+}
+
+message GetClubResponse {
+  string name = 1;
+  repeated ClubGroup groups = 2;
+}
+
+message ClubGroup {
+  string group = 1;
+  repeated ClubPlayerItem players = 2;
+}
+
+message ClubPlayerItem {
+  int32 dtb_id = 1;
+  string lastname = 2;
+  string firstname = 3;
+  int32 rank = 4;
+  string score = 5;
+}

--- a/src/main/proto/common.proto
+++ b/src/main/proto/common.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+package rankinginfo.v1;
+
+option java_package = "de.hdawg.rankinginfo.grpc.v1";
+option java_multiple_files = true;
+
+message PageInfo {
+  int32 page = 1;
+  int32 per_page = 2;
+  int64 total_count = 3;
+}

--- a/src/main/proto/player.proto
+++ b/src/main/proto/player.proto
@@ -1,0 +1,50 @@
+syntax = "proto3";
+
+package rankinginfo.v1;
+
+option java_package = "de.hdawg.rankinginfo.grpc.v1";
+option java_multiple_files = true;
+
+service PlayerService {
+  rpc SearchPlayers(SearchPlayersRequest) returns (SearchPlayersResponse);
+  rpc GetPlayer(GetPlayerRequest) returns (GetPlayerResponse);
+}
+
+message SearchPlayersRequest {
+  string lastname = 1;
+  string yob = 2;
+}
+
+message SearchPlayersResponse {
+  SearchPlayersRequest request = 1;
+  repeated PlayerSearchItem items = 2;
+  int32 total_count = 3;
+}
+
+message PlayerSearchItem {
+  int32 dtb_id = 1;
+  string lastname = 2;
+  string firstname = 3;
+  string club = 4;
+}
+
+message GetPlayerRequest {
+  int32 dtb_id = 1;
+}
+
+message GetPlayerResponse {
+  int32 dtb_id = 1;
+  string lastname = 2;
+  string firstname = 3;
+  string nationality = 4;
+  string club = 5;
+  string federation = 6;
+  repeated PlayerRankingEntry rankings = 7;
+}
+
+message PlayerRankingEntry {
+  string quarter = 1;
+  string age_group = 2;
+  int32 ranking_position = 3;
+  string score = 4;
+}

--- a/src/main/proto/ranking.proto
+++ b/src/main/proto/ranking.proto
@@ -1,0 +1,41 @@
+syntax = "proto3";
+
+package rankinginfo.v1;
+
+option java_package = "de.hdawg.rankinginfo.grpc.v1";
+option java_multiple_files = true;
+
+import "common.proto";
+
+service RankingService {
+  rpc ListListings(ListListingsRequest) returns (ListListingsResponse);
+}
+
+message ListListingsRequest {
+  string quarter = 1;
+  string age_group_slug = 2;
+  int32 page = 3;
+  int32 per_page = 4;
+  string federation = 5;
+  string club = 6;
+  string age_group_options = 7;
+  bool year_end = 8;
+}
+
+message ListListingsResponse {
+  ListListingsRequest request = 1;
+  repeated ListingItem items = 2;
+  rankinginfo.v1.PageInfo page_info = 3;
+}
+
+message ListingItem {
+  int32 dtb_id = 1;
+  int32 ranking_position = 2;
+  string lastname = 3;
+  string firstname = 4;
+  string nationality = 5;
+  string club = 6;
+  string federation = 7;
+  string score = 8;
+  optional int32 position_change = 9;
+}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -11,5 +11,11 @@ api:
   tokens:
     - test-api-token
 
+grpc:
+  server:
+    port: 9095
+    reflection-service-enabled: true
+    health-service-enabled: true
+
 import:
   schedule: "-"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,6 +22,12 @@ server:
 api:
   tokens: []
 
+grpc:
+  server:
+    port: 9090
+    reflection-service-enabled: true
+    health-service-enabled: true
+
 import:
   folder: ${IMPORT_FOLDER:${user.home}/ranking-import}
   schedule: "${IMPORT_SCHEDULE:0 0 12 * * ?}"

--- a/src/test/java/de/hdawg/rankinginfo/api/security/ApiTokenValidatorTest.java
+++ b/src/test/java/de/hdawg/rankinginfo/api/security/ApiTokenValidatorTest.java
@@ -1,0 +1,61 @@
+package de.hdawg.rankinginfo.api.security;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import de.hdawg.rankinginfo.config.ApiProperties;
+
+class ApiTokenValidatorTest {
+
+  @BeforeEach
+  void setUp() {
+    System.setProperty("API_BEARER_TOKEN", "");
+  }
+
+  @AfterEach
+  void tearDown() {
+    System.clearProperty("API_BEARER_TOKEN");
+  }
+
+  @Test
+  @DisplayName("accepts a configured token")
+  void acceptsConfiguredToken() {
+    var validator = new ApiTokenValidator(new ApiProperties(List.of("valid-token")));
+
+    assertTrue(validator.isValid("valid-token"));
+  }
+
+  @Test
+  @DisplayName("rejects an unconfigured token")
+  void rejectsUnconfiguredToken() {
+    var validator = new ApiTokenValidator(new ApiProperties(List.of("valid-token")));
+
+    assertFalse(validator.isValid("wrong-token"));
+  }
+
+  @Test
+  @DisplayName("ignores blank tokens in configuration")
+  void ignoresBlankTokensInConfiguration() {
+    var validator = new ApiTokenValidator(new ApiProperties(List.of("  ", "", "valid-token")));
+
+    assertFalse(validator.isValid("  "));
+    assertTrue(validator.isValid("valid-token"));
+  }
+
+  @Test
+  @DisplayName("accepts any token from a multi-token configuration")
+  void acceptsAnyTokenFromMultiTokenConfig() {
+    var validator = new ApiTokenValidator(new ApiProperties(List.of("token-a", "token-b", "token-c")));
+
+    assertTrue(validator.isValid("token-a"));
+    assertTrue(validator.isValid("token-b"));
+    assertTrue(validator.isValid("token-c"));
+  }
+}

--- a/src/test/java/de/hdawg/rankinginfo/api/security/BearerTokenFilterTest.java
+++ b/src/test/java/de/hdawg/rankinginfo/api/security/BearerTokenFilterTest.java
@@ -21,6 +21,8 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import tools.jackson.databind.ObjectMapper;
 
+import de.hdawg.rankinginfo.config.ApiProperties;
+
 class BearerTokenFilterTest {
 
   private final ObjectMapper objectMapper = new ObjectMapper();
@@ -41,7 +43,7 @@ class BearerTokenFilterTest {
   }
 
   private BearerTokenFilter filter(List<String> tokens) {
-    return new BearerTokenFilter(tokens, objectMapper);
+    return new BearerTokenFilter(new ApiTokenValidator(new ApiProperties(tokens)), objectMapper);
   }
 
   @Test
@@ -83,7 +85,8 @@ class BearerTokenFilterTest {
   @Test
   @DisplayName("accepts token from configured tokens list")
   void acceptsTokenFromConfiguredTokensList() throws Exception {
-    var filterWithToken = new BearerTokenFilter(List.of("env-token"), objectMapper);
+    var filterWithToken =
+        new BearerTokenFilter(new ApiTokenValidator(new ApiProperties(List.of("env-token"))), objectMapper);
     var request = new MockHttpServletRequest();
     request.addHeader("Authorization", "Bearer env-token");
     var response = new MockHttpServletResponse();

--- a/src/test/java/de/hdawg/rankinginfo/api/security/RequestRateLimiterTest.java
+++ b/src/test/java/de/hdawg/rankinginfo/api/security/RequestRateLimiterTest.java
@@ -1,0 +1,43 @@
+package de.hdawg.rankinginfo.api.security;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class RequestRateLimiterTest {
+
+  @Test
+  @DisplayName("allows requests within the limit")
+  void allowsRequestsWithinLimit() {
+    var rateLimiter = new RequestRateLimiter();
+
+    assertTrue(rateLimiter.tryConsume("key-a"));
+  }
+
+  @Test
+  @DisplayName("rejects requests once the bucket for a key is exhausted")
+  void rejectsRequestsOnceBucketExhausted() {
+    var rateLimiter = new RequestRateLimiter();
+
+    for (int i = 0; i < 1000; i++) {
+      assertTrue(rateLimiter.tryConsume("key-b"), "expected request " + i + " to be allowed");
+    }
+
+    assertFalse(rateLimiter.tryConsume("key-b"));
+  }
+
+  @Test
+  @DisplayName("tracks separate buckets per key")
+  void tracksSeparateBucketsPerKey() {
+    var rateLimiter = new RequestRateLimiter();
+
+    for (int i = 0; i < 1000; i++) {
+      rateLimiter.tryConsume("exhausted-key");
+    }
+    assertFalse(rateLimiter.tryConsume("exhausted-key"));
+
+    assertTrue(rateLimiter.tryConsume("fresh-key"));
+  }
+}

--- a/src/test/java/de/hdawg/rankinginfo/grpc/ClubGrpcServiceTest.java
+++ b/src/test/java/de/hdawg/rankinginfo/grpc/ClubGrpcServiceTest.java
@@ -1,0 +1,109 @@
+package de.hdawg.rankinginfo.grpc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.MetadataUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.CacheManager;
+
+import de.hdawg.rankinginfo.domain.Ranking;
+import de.hdawg.rankinginfo.grpc.v1.ClubServiceGrpc;
+import de.hdawg.rankinginfo.grpc.v1.GetClubRequest;
+import de.hdawg.rankinginfo.grpc.v1.SearchClubsRequest;
+import de.hdawg.rankinginfo.repository.ImportHistoryRepository;
+import de.hdawg.rankinginfo.repository.RankingRepository;
+
+@SpringBootTest
+class ClubGrpcServiceTest {
+
+  @Autowired RankingRepository rankingRepository;
+  @Autowired ImportHistoryRepository importHistoryRepository;
+  @Autowired CacheManager cacheManager;
+
+  private ManagedChannel channel;
+  private ClubServiceGrpc.ClubServiceBlockingStub authedStub;
+
+  @BeforeEach
+  void setUp() {
+    var q = LocalDate.parse("2026-04-01");
+    rankingRepository.saveAll(
+        List.of(
+            new Ranking(0, 10_001_001, "Mueller", "Hans", "GER", "m00", q, 1, "500", "TC Test", "WTV", false, false, false)));
+    var cache = cacheManager.getCache("available_dates");
+    if (cache != null) {
+      cache.clear();
+    }
+
+    channel = ManagedChannelBuilder.forAddress("localhost", 9095).usePlaintext().build();
+    var metadata = new Metadata();
+    metadata.put(GrpcAuthInterceptor.AUTHORIZATION_KEY, "Bearer test-api-token");
+    authedStub =
+        ClubServiceGrpc.newBlockingStub(channel)
+            .withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata));
+  }
+
+  @AfterEach
+  void tearDown() {
+    channel.shutdownNow();
+    rankingRepository.deleteAll();
+    importHistoryRepository.deleteAll();
+  }
+
+  @Test
+  @DisplayName("rejects blank name as INVALID_ARGUMENT")
+  void rejectsBlankName() {
+    var request = SearchClubsRequest.newBuilder().setName("").build();
+
+    var ex = assertThrows(StatusRuntimeException.class, () -> authedStub.searchClubs(request));
+
+    assertEquals(Status.Code.INVALID_ARGUMENT, ex.getStatus().getCode());
+  }
+
+  @Test
+  @DisplayName("searches clubs by name")
+  void searchesClubsByName() {
+    var request = SearchClubsRequest.newBuilder().setName("TC Test").build();
+
+    var response = authedStub.searchClubs(request);
+
+    assertEquals(1, response.getItemsCount());
+    assertEquals("TC Test", response.getItems(0).getName());
+    assertEquals(1, response.getItems(0).getAdultCount());
+  }
+
+  @Test
+  @DisplayName("returns NOT_FOUND for unknown club")
+  void returnsNotFoundForUnknownClub() {
+    var request = GetClubRequest.newBuilder().setId("Unknown Club").build();
+
+    var ex = assertThrows(StatusRuntimeException.class, () -> authedStub.getClub(request));
+
+    assertEquals(Status.Code.NOT_FOUND, ex.getStatus().getCode());
+  }
+
+  @Test
+  @DisplayName("returns club roster grouped by category")
+  void returnsClubRoster() {
+    var request = GetClubRequest.newBuilder().setId("TC Test").build();
+
+    var response = authedStub.getClub(request);
+
+    assertEquals(1, response.getGroupsCount());
+    assertEquals("Herren", response.getGroups(0).getGroup());
+    assertEquals(1, response.getGroups(0).getPlayersCount());
+  }
+}

--- a/src/test/java/de/hdawg/rankinginfo/grpc/ClubGrpcServiceTest.java
+++ b/src/test/java/de/hdawg/rankinginfo/grpc/ClubGrpcServiceTest.java
@@ -30,6 +30,8 @@ import de.hdawg.rankinginfo.repository.RankingRepository;
 @SpringBootTest
 class ClubGrpcServiceTest {
 
+  private static final int GRPC_TEST_PORT = 9095;
+
   @Autowired RankingRepository rankingRepository;
   @Autowired ImportHistoryRepository importHistoryRepository;
   @Autowired CacheManager cacheManager;
@@ -48,7 +50,7 @@ class ClubGrpcServiceTest {
       cache.clear();
     }
 
-    channel = ManagedChannelBuilder.forAddress("localhost", 9095).usePlaintext().build();
+    channel = ManagedChannelBuilder.forAddress("localhost", GRPC_TEST_PORT).usePlaintext().build();
     var metadata = new Metadata();
     metadata.put(GrpcAuthInterceptor.AUTHORIZATION_KEY, "Bearer test-api-token");
     authedStub =

--- a/src/test/java/de/hdawg/rankinginfo/grpc/GrpcAuthInterceptorTest.java
+++ b/src/test/java/de/hdawg/rankinginfo/grpc/GrpcAuthInterceptorTest.java
@@ -1,0 +1,118 @@
+package de.hdawg.rankinginfo.grpc;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.Status;
+import org.junit.jupiter.api.Test;
+
+import de.hdawg.rankinginfo.api.security.ApiTokenValidator;
+import de.hdawg.rankinginfo.config.ApiProperties;
+
+class GrpcAuthInterceptorTest {
+
+  private final ApiTokenValidator tokenValidator =
+      new ApiTokenValidator(new ApiProperties(List.of("valid-token")));
+  private final GrpcAuthInterceptor interceptor = new GrpcAuthInterceptor(tokenValidator);
+
+  @SuppressWarnings("unchecked")
+  private ServerCall<Object, Object> mockCall(String serviceName) {
+    var call = (ServerCall<Object, Object>) mock(ServerCall.class);
+    var method =
+        MethodDescriptor.newBuilder(mock(MethodDescriptor.Marshaller.class), mock(MethodDescriptor.Marshaller.class))
+            .setFullMethodName(serviceName + "/SomeMethod")
+            .setType(MethodDescriptor.MethodType.UNARY)
+            .build();
+    when(call.getMethodDescriptor()).thenReturn((MethodDescriptor) method);
+    return call;
+  }
+
+  @SuppressWarnings("unchecked")
+  private ServerCallHandler<Object, Object> handlerReturning(AtomicBoolean called) {
+    ServerCallHandler<Object, Object> handler = mock(ServerCallHandler.class);
+    when(handler.startCall(any(), any()))
+        .thenAnswer(
+            invocation -> {
+              called.set(true);
+              return mock(ServerCall.Listener.class);
+            });
+    return handler;
+  }
+
+  @Test
+  void passesCallWithValidToken() {
+    var call = mockCall("rankinginfo.v1.RankingService");
+    var headers = new Metadata();
+    headers.put(GrpcAuthInterceptor.AUTHORIZATION_KEY, "Bearer valid-token");
+    var called = new AtomicBoolean(false);
+
+    interceptor.interceptCall(call, headers, handlerReturning(called));
+
+    assertTrue(called.get());
+    verify(call, never()).close(any(), any());
+  }
+
+  @Test
+  void rejectsCallWithMissingToken() {
+    var call = mockCall("rankinginfo.v1.RankingService");
+    var headers = new Metadata();
+    var called = new AtomicBoolean(false);
+
+    interceptor.interceptCall(call, headers, handlerReturning(called));
+
+    assertFalse(called.get());
+    verify(call, times(1)).close(argThatUnauthenticated(), any());
+  }
+
+  @Test
+  void rejectsCallWithWrongToken() {
+    var call = mockCall("rankinginfo.v1.RankingService");
+    var headers = new Metadata();
+    headers.put(GrpcAuthInterceptor.AUTHORIZATION_KEY, "Bearer wrong-token");
+    var called = new AtomicBoolean(false);
+
+    interceptor.interceptCall(call, headers, handlerReturning(called));
+
+    assertFalse(called.get());
+  }
+
+  @Test
+  void allowsHealthCheckWithoutToken() {
+    var call = mockCall("grpc.health.v1.Health");
+    var headers = new Metadata();
+    var called = new AtomicBoolean(false);
+
+    interceptor.interceptCall(call, headers, handlerReturning(called));
+
+    assertTrue(called.get());
+  }
+
+  @Test
+  void allowsReflectionWithoutToken() {
+    var call = mockCall("grpc.reflection.v1alpha.ServerReflection");
+    var headers = new Metadata();
+    var called = new AtomicBoolean(false);
+
+    interceptor.interceptCall(call, headers, handlerReturning(called));
+
+    assertTrue(called.get());
+  }
+
+  private static Status argThatUnauthenticated() {
+    return org.mockito.ArgumentMatchers.argThat(
+        status -> status != null && status.getCode() == Status.Code.UNAUTHENTICATED);
+  }
+}

--- a/src/test/java/de/hdawg/rankinginfo/grpc/GrpcExceptionAdviceTest.java
+++ b/src/test/java/de/hdawg/rankinginfo/grpc/GrpcExceptionAdviceTest.java
@@ -1,0 +1,42 @@
+package de.hdawg.rankinginfo.grpc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.NoSuchElementException;
+
+import io.grpc.Status;
+import org.junit.jupiter.api.Test;
+
+class GrpcExceptionAdviceTest {
+
+  private final GrpcExceptionAdvice advice = new GrpcExceptionAdvice();
+
+  @Test
+  void mapsNoSuchElementExceptionToNotFound() {
+    var status = advice.handleNotFound(new NoSuchElementException("missing"));
+
+    assertEquals(Status.Code.NOT_FOUND, status.getCode());
+  }
+
+  @Test
+  void mapsIndexOutOfBoundsExceptionToNotFound() {
+    var status = advice.handleNotFound(new IndexOutOfBoundsException("out of bounds"));
+
+    assertEquals(Status.Code.NOT_FOUND, status.getCode());
+  }
+
+  @Test
+  void mapsIllegalArgumentExceptionToInvalidArgument() {
+    var status = advice.handleIllegalArgument(new IllegalArgumentException("bad input"));
+
+    assertEquals(Status.Code.INVALID_ARGUMENT, status.getCode());
+    assertEquals("bad input", status.getDescription());
+  }
+
+  @Test
+  void mapsGenericExceptionToInternal() {
+    var status = advice.handleException(new RuntimeException("boom"));
+
+    assertEquals(Status.Code.INTERNAL, status.getCode());
+  }
+}

--- a/src/test/java/de/hdawg/rankinginfo/grpc/GrpcRateLimitInterceptorTest.java
+++ b/src/test/java/de/hdawg/rankinginfo/grpc/GrpcRateLimitInterceptorTest.java
@@ -1,0 +1,110 @@
+package de.hdawg.rankinginfo.grpc;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.InetSocketAddress;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.grpc.Attributes;
+import io.grpc.Grpc;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import org.junit.jupiter.api.Test;
+
+import de.hdawg.rankinginfo.api.security.RequestRateLimiter;
+
+class GrpcRateLimitInterceptorTest {
+
+  private final RequestRateLimiter rateLimiter = new RequestRateLimiter();
+  private final GrpcRateLimitInterceptor interceptor = new GrpcRateLimitInterceptor(rateLimiter);
+
+  @SuppressWarnings("unchecked")
+  private ServerCall<Object, Object> mockCall() {
+    var call = (ServerCall<Object, Object>) mock(ServerCall.class);
+    var method =
+        MethodDescriptor.newBuilder(mock(MethodDescriptor.Marshaller.class), mock(MethodDescriptor.Marshaller.class))
+            .setFullMethodName("rankinginfo.v1.RankingService/SomeMethod")
+            .setType(MethodDescriptor.MethodType.UNARY)
+            .build();
+    when(call.getMethodDescriptor()).thenReturn((MethodDescriptor) method);
+    var attributes =
+        Attributes.newBuilder()
+            .set(Grpc.TRANSPORT_ATTR_REMOTE_ADDR, new InetSocketAddress("127.0.0.1", 12345))
+            .build();
+    when(call.getAttributes()).thenReturn(attributes);
+    return call;
+  }
+
+  @SuppressWarnings("unchecked")
+  private ServerCallHandler<Object, Object> handlerReturning(AtomicBoolean called) {
+    ServerCallHandler<Object, Object> handler = mock(ServerCallHandler.class);
+    when(handler.startCall(any(), any()))
+        .thenAnswer(
+            invocation -> {
+              called.set(true);
+              return mock(ServerCall.Listener.class);
+            });
+    return handler;
+  }
+
+  @Test
+  void allowsRequestsWithinLimit() {
+    var call = mockCall();
+    var headers = new Metadata();
+    headers.put(GrpcAuthInterceptor.AUTHORIZATION_KEY, "Bearer some-token");
+    var called = new AtomicBoolean(false);
+
+    interceptor.interceptCall(call, headers, handlerReturning(called));
+
+    assertTrue(called.get());
+  }
+
+  @Test
+  void rejectsRequestsOnceBucketExhausted() {
+    var headers = new Metadata();
+    headers.put(GrpcAuthInterceptor.AUTHORIZATION_KEY, "Bearer exhausted-token");
+
+    for (int i = 0; i < 1000; i++) {
+      interceptor.interceptCall(mockCall(), headers, handlerReturning(new AtomicBoolean()));
+    }
+
+    var called = new AtomicBoolean(false);
+    interceptor.interceptCall(mockCall(), headers, handlerReturning(called));
+
+    assertFalse(called.get());
+  }
+
+  @Test
+  void fallsBackToRemoteAddressWhenNoAuthorizationHeader() {
+    var call = mockCall();
+    var headers = new Metadata();
+    var called = new AtomicBoolean(false);
+
+    interceptor.interceptCall(call, headers, handlerReturning(called));
+
+    assertTrue(called.get());
+  }
+
+  @Test
+  void allowsHealthCheckWithoutRateLimiting() {
+    var call = mock(ServerCall.class);
+    var method =
+        MethodDescriptor.newBuilder(mock(MethodDescriptor.Marshaller.class), mock(MethodDescriptor.Marshaller.class))
+            .setFullMethodName("grpc.health.v1.Health/Check")
+            .setType(MethodDescriptor.MethodType.UNARY)
+            .build();
+    when(call.getMethodDescriptor()).thenReturn((MethodDescriptor) method);
+    var headers = new Metadata();
+    var called = new AtomicBoolean(false);
+
+    interceptor.interceptCall(call, headers, handlerReturning(called));
+
+    assertTrue(called.get());
+  }
+}

--- a/src/test/java/de/hdawg/rankinginfo/grpc/GrpcRateLimitInterceptorTest.java
+++ b/src/test/java/de/hdawg/rankinginfo/grpc/GrpcRateLimitInterceptorTest.java
@@ -24,8 +24,12 @@ class GrpcRateLimitInterceptorTest {
   private final RequestRateLimiter rateLimiter = new RequestRateLimiter();
   private final GrpcRateLimitInterceptor interceptor = new GrpcRateLimitInterceptor(rateLimiter);
 
-  @SuppressWarnings("unchecked")
   private ServerCall<Object, Object> mockCall() {
+    return mockCall(12345);
+  }
+
+  @SuppressWarnings("unchecked")
+  private ServerCall<Object, Object> mockCall(int remotePort) {
     var call = (ServerCall<Object, Object>) mock(ServerCall.class);
     var method =
         MethodDescriptor.newBuilder(mock(MethodDescriptor.Marshaller.class), mock(MethodDescriptor.Marshaller.class))
@@ -35,7 +39,7 @@ class GrpcRateLimitInterceptorTest {
     when(call.getMethodDescriptor()).thenReturn((MethodDescriptor) method);
     var attributes =
         Attributes.newBuilder()
-            .set(Grpc.TRANSPORT_ATTR_REMOTE_ADDR, new InetSocketAddress("127.0.0.1", 12345))
+            .set(Grpc.TRANSPORT_ATTR_REMOTE_ADDR, new InetSocketAddress("127.0.0.1", remotePort))
             .build();
     when(call.getAttributes()).thenReturn(attributes);
     return call;
@@ -89,6 +93,20 @@ class GrpcRateLimitInterceptorTest {
     interceptor.interceptCall(call, headers, handlerReturning(called));
 
     assertTrue(called.get());
+  }
+
+  @Test
+  void sameIpDifferentPortsShareRateLimitBucket() {
+    var headers = new Metadata();
+
+    for (int i = 0; i < 1000; i++) {
+      interceptor.interceptCall(mockCall(20000 + i), headers, handlerReturning(new AtomicBoolean()));
+    }
+
+    var called = new AtomicBoolean(false);
+    interceptor.interceptCall(mockCall(54321), headers, handlerReturning(called));
+
+    assertFalse(called.get());
   }
 
   @Test

--- a/src/test/java/de/hdawg/rankinginfo/grpc/GrpcServerSmokeTest.java
+++ b/src/test/java/de/hdawg/rankinginfo/grpc/GrpcServerSmokeTest.java
@@ -18,11 +18,13 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class GrpcServerSmokeTest {
 
+  private static final int GRPC_TEST_PORT = 9095;
+
   private ManagedChannel channel;
 
   @BeforeEach
   void setUp() {
-    channel = ManagedChannelBuilder.forAddress("localhost", 9095).usePlaintext().build();
+    channel = ManagedChannelBuilder.forAddress("localhost", GRPC_TEST_PORT).usePlaintext().build();
   }
 
   @AfterEach

--- a/src/test/java/de/hdawg/rankinginfo/grpc/GrpcServerSmokeTest.java
+++ b/src/test/java/de/hdawg/rankinginfo/grpc/GrpcServerSmokeTest.java
@@ -41,8 +41,8 @@ class GrpcServerSmokeTest {
   }
 
   @Test
-  @DisplayName("a business RPC without a token is rejected as UNAUTHENTICATED")
-  void businessRpcWithoutTokenIsRejected() {
+  @DisplayName("health check succeeds even with a bad API token (allow-list bypass)")
+  void healthCheckSucceedsEvenWithBadToken() {
     // RankingService doesn't exist yet (Task 8); this test intentionally targets the
     // reflection service's own descriptor RPC instead, which IS on the public-services
     // allow-list, to only prove the server + interceptor wiring is live before any

--- a/src/test/java/de/hdawg/rankinginfo/grpc/GrpcServerSmokeTest.java
+++ b/src/test/java/de/hdawg/rankinginfo/grpc/GrpcServerSmokeTest.java
@@ -1,0 +1,62 @@
+package de.hdawg.rankinginfo.grpc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.health.v1.HealthCheckRequest;
+import io.grpc.health.v1.HealthCheckResponse;
+import io.grpc.health.v1.HealthGrpc;
+import io.grpc.stub.MetadataUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class GrpcServerSmokeTest {
+
+  private ManagedChannel channel;
+
+  @BeforeEach
+  void setUp() {
+    channel = ManagedChannelBuilder.forAddress("localhost", 9095).usePlaintext().build();
+  }
+
+  @AfterEach
+  void tearDown() {
+    channel.shutdownNow();
+  }
+
+  @Test
+  @DisplayName("health check succeeds without an API token")
+  void healthCheckSucceedsWithoutToken() {
+    var stub = HealthGrpc.newBlockingStub(channel);
+
+    var response = stub.check(HealthCheckRequest.newBuilder().build());
+
+    assertEquals(HealthCheckResponse.ServingStatus.SERVING, response.getStatus());
+  }
+
+  @Test
+  @DisplayName("a business RPC without a token is rejected as UNAUTHENTICATED")
+  void businessRpcWithoutTokenIsRejected() {
+    // RankingService doesn't exist yet (Task 8); this test intentionally targets the
+    // reflection service's own descriptor RPC instead, which IS on the public-services
+    // allow-list, to only prove the server + interceptor wiring is live before any
+    // business service exists. Replace with a real business-service call in Task 8's tests.
+    var stub = HealthGrpc.newBlockingStub(channel);
+    var metadata = new Metadata();
+    metadata.put(GrpcAuthInterceptor.AUTHORIZATION_KEY, "Bearer wrong-token");
+    var stubWithBadAuth =
+        stub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata));
+
+    // Health is public, so even a bad token must still succeed here — this proves the
+    // allow-list bypass, not rejection. A true 401 case is exercised once Task 8 adds a
+    // business RPC.
+    var response = stubWithBadAuth.check(HealthCheckRequest.newBuilder().build());
+    assertEquals(HealthCheckResponse.ServingStatus.SERVING, response.getStatus());
+  }
+}

--- a/src/test/java/de/hdawg/rankinginfo/grpc/ListingsParityTest.java
+++ b/src/test/java/de/hdawg/rankinginfo/grpc/ListingsParityTest.java
@@ -31,6 +31,8 @@ import de.hdawg.rankinginfo.repository.RankingRepository;
 @AutoConfigureMockMvc
 class ListingsParityTest {
 
+  private static final int GRPC_TEST_PORT = 9095;
+
   @Autowired MockMvc mockMvc;
   @Autowired RankingRepository rankingRepository;
   @Autowired ImportHistoryRepository importHistoryRepository;
@@ -52,7 +54,7 @@ class ListingsParityTest {
       cache.clear();
     }
 
-    channel = ManagedChannelBuilder.forAddress("localhost", 9095).usePlaintext().build();
+    channel = ManagedChannelBuilder.forAddress("localhost", GRPC_TEST_PORT).usePlaintext().build();
     var metadata = new Metadata();
     metadata.put(GrpcAuthInterceptor.AUTHORIZATION_KEY, "Bearer test-api-token");
     grpcStub =
@@ -90,6 +92,10 @@ class ListingsParityTest {
       assertEquals(restItem.get("dtb_id").asInt(), grpcItem.getDtbId());
       assertEquals(restItem.get("ranking_position").asInt(), grpcItem.getRankingPosition());
       assertEquals(restItem.get("lastname").asText(), grpcItem.getLastname());
+      assertEquals(restItem.get("firstname").asText(), grpcItem.getFirstname());
+      assertEquals(restItem.get("nationality").asText(), grpcItem.getNationality());
+      assertEquals(restItem.get("club").asText(), grpcItem.getClub());
+      assertEquals(restItem.get("federation").asText(), grpcItem.getFederation());
       assertEquals(restItem.get("score").asText(), grpcItem.getScore());
     }
   }

--- a/src/test/java/de/hdawg/rankinginfo/grpc/ListingsParityTest.java
+++ b/src/test/java/de/hdawg/rankinginfo/grpc/ListingsParityTest.java
@@ -1,0 +1,96 @@
+package de.hdawg.rankinginfo.grpc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.stub.MetadataUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.cache.CacheManager;
+import org.springframework.test.web.servlet.MockMvc;
+import tools.jackson.databind.ObjectMapper;
+
+import de.hdawg.rankinginfo.domain.Ranking;
+import de.hdawg.rankinginfo.grpc.v1.ListListingsRequest;
+import de.hdawg.rankinginfo.grpc.v1.RankingServiceGrpc;
+import de.hdawg.rankinginfo.repository.ImportHistoryRepository;
+import de.hdawg.rankinginfo.repository.RankingRepository;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class ListingsParityTest {
+
+  @Autowired MockMvc mockMvc;
+  @Autowired RankingRepository rankingRepository;
+  @Autowired ImportHistoryRepository importHistoryRepository;
+  @Autowired CacheManager cacheManager;
+
+  private final String quarter = "2026-04-01";
+  private ManagedChannel channel;
+  private RankingServiceGrpc.RankingServiceBlockingStub grpcStub;
+
+  @BeforeEach
+  void setUp() {
+    var q = LocalDate.parse(quarter);
+    rankingRepository.saveAll(
+        List.of(
+            new Ranking(0, 10_001_001, "Mueller", "Hans", "GER", "m00", q, 1, "500", "TC Test", "WTV", false, false, false),
+            new Ranking(0, 10_002_002, "Schmidt", "Peter", "GER", "m00", q, 2, "490", "TC Test", "WTV", false, false, false)));
+    var cache = cacheManager.getCache("available_dates");
+    if (cache != null) {
+      cache.clear();
+    }
+
+    channel = ManagedChannelBuilder.forAddress("localhost", 9095).usePlaintext().build();
+    var metadata = new Metadata();
+    metadata.put(GrpcAuthInterceptor.AUTHORIZATION_KEY, "Bearer test-api-token");
+    grpcStub =
+        RankingServiceGrpc.newBlockingStub(channel)
+            .withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata));
+  }
+
+  @AfterEach
+  void tearDown() {
+    channel.shutdownNow();
+    rankingRepository.deleteAll();
+    importHistoryRepository.deleteAll();
+  }
+
+  @Test
+  @DisplayName("REST and gRPC return the same items for identical parameters")
+  void restAndGrpcReturnSameItems() throws Exception {
+    var restResult =
+        mockMvc
+            .perform(
+                get("/api/v1/listings/" + quarter + "/m00")
+                    .header("Authorization", "Bearer test-api-token"))
+            .andReturn();
+    var restBody = new ObjectMapper().readTree(restResult.getResponse().getContentAsString());
+    var restItems = restBody.get("data");
+
+    var grpcResponse =
+        grpcStub.listListings(
+            ListListingsRequest.newBuilder().setQuarter(quarter).setAgeGroupSlug("m00").setPage(1).setPerPage(25).build());
+
+    assertEquals(restItems.size(), grpcResponse.getItemsCount());
+    for (int i = 0; i < grpcResponse.getItemsCount(); i++) {
+      var restItem = restItems.get(i);
+      var grpcItem = grpcResponse.getItems(i);
+      assertEquals(restItem.get("dtb_id").asInt(), grpcItem.getDtbId());
+      assertEquals(restItem.get("ranking_position").asInt(), grpcItem.getRankingPosition());
+      assertEquals(restItem.get("lastname").asText(), grpcItem.getLastname());
+      assertEquals(restItem.get("score").asText(), grpcItem.getScore());
+    }
+  }
+}

--- a/src/test/java/de/hdawg/rankinginfo/grpc/PlayerGrpcServiceTest.java
+++ b/src/test/java/de/hdawg/rankinginfo/grpc/PlayerGrpcServiceTest.java
@@ -29,6 +29,8 @@ import de.hdawg.rankinginfo.repository.RankingRepository;
 @SpringBootTest
 class PlayerGrpcServiceTest {
 
+  private static final int GRPC_TEST_PORT = 9095;
+
   @Autowired RankingRepository rankingRepository;
   @Autowired ImportHistoryRepository importHistoryRepository;
 
@@ -41,7 +43,7 @@ class PlayerGrpcServiceTest {
         List.of(
             new Ranking(0, 10_001_001, "Mueller", "Hans", "GER", "m00", LocalDate.parse("2026-04-01"), 1, "500", "TC Test", "WTV", false, false, false)));
 
-    channel = ManagedChannelBuilder.forAddress("localhost", 9095).usePlaintext().build();
+    channel = ManagedChannelBuilder.forAddress("localhost", GRPC_TEST_PORT).usePlaintext().build();
     var metadata = new Metadata();
     metadata.put(GrpcAuthInterceptor.AUTHORIZATION_KEY, "Bearer test-api-token");
     authedStub =

--- a/src/test/java/de/hdawg/rankinginfo/grpc/PlayerGrpcServiceTest.java
+++ b/src/test/java/de/hdawg/rankinginfo/grpc/PlayerGrpcServiceTest.java
@@ -1,0 +1,110 @@
+package de.hdawg.rankinginfo.grpc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.MetadataUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import de.hdawg.rankinginfo.domain.Ranking;
+import de.hdawg.rankinginfo.grpc.v1.GetPlayerRequest;
+import de.hdawg.rankinginfo.grpc.v1.PlayerServiceGrpc;
+import de.hdawg.rankinginfo.grpc.v1.SearchPlayersRequest;
+import de.hdawg.rankinginfo.repository.ImportHistoryRepository;
+import de.hdawg.rankinginfo.repository.RankingRepository;
+
+@SpringBootTest
+class PlayerGrpcServiceTest {
+
+  @Autowired RankingRepository rankingRepository;
+  @Autowired ImportHistoryRepository importHistoryRepository;
+
+  private ManagedChannel channel;
+  private PlayerServiceGrpc.PlayerServiceBlockingStub authedStub;
+
+  @BeforeEach
+  void setUp() {
+    rankingRepository.saveAll(
+        List.of(
+            new Ranking(0, 10_001_001, "Mueller", "Hans", "GER", "m00", LocalDate.parse("2026-04-01"), 1, "500", "TC Test", "WTV", false, false, false)));
+
+    channel = ManagedChannelBuilder.forAddress("localhost", 9095).usePlaintext().build();
+    var metadata = new Metadata();
+    metadata.put(GrpcAuthInterceptor.AUTHORIZATION_KEY, "Bearer test-api-token");
+    authedStub =
+        PlayerServiceGrpc.newBlockingStub(channel)
+            .withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata));
+  }
+
+  @AfterEach
+  void tearDown() {
+    channel.shutdownNow();
+    rankingRepository.deleteAll();
+    importHistoryRepository.deleteAll();
+  }
+
+  @Test
+  @DisplayName("rejects blank lastname as INVALID_ARGUMENT")
+  void rejectsBlankLastname() {
+    var request = SearchPlayersRequest.newBuilder().setLastname("").build();
+
+    var ex = assertThrows(StatusRuntimeException.class, () -> authedStub.searchPlayers(request));
+
+    assertEquals(Status.Code.INVALID_ARGUMENT, ex.getStatus().getCode());
+  }
+
+  @Test
+  @DisplayName("returns NOT_FOUND when no players match")
+  void returnsNotFoundWhenNoMatch() {
+    var request = SearchPlayersRequest.newBuilder().setLastname("Nobody").build();
+
+    var ex = assertThrows(StatusRuntimeException.class, () -> authedStub.searchPlayers(request));
+
+    assertEquals(Status.Code.NOT_FOUND, ex.getStatus().getCode());
+  }
+
+  @Test
+  @DisplayName("searches players by lastname")
+  void searchesPlayersByLastname() {
+    var request = SearchPlayersRequest.newBuilder().setLastname("Mueller").build();
+
+    var response = authedStub.searchPlayers(request);
+
+    assertEquals(1, response.getItemsCount());
+    assertEquals(10_001_001, response.getItems(0).getDtbId());
+  }
+
+  @Test
+  @DisplayName("returns player detail with ranking history")
+  void returnsPlayerDetail() {
+    var request = GetPlayerRequest.newBuilder().setDtbId(10_001_001).build();
+
+    var response = authedStub.getPlayer(request);
+
+    assertEquals("Mueller", response.getLastname());
+    assertEquals(1, response.getRankingsCount());
+  }
+
+  @Test
+  @DisplayName("returns NOT_FOUND for unknown player id")
+  void returnsNotFoundForUnknownPlayer() {
+    var request = GetPlayerRequest.newBuilder().setDtbId(99_999_999).build();
+
+    var ex = assertThrows(StatusRuntimeException.class, () -> authedStub.getPlayer(request));
+
+    assertEquals(Status.Code.NOT_FOUND, ex.getStatus().getCode());
+  }
+}

--- a/src/test/java/de/hdawg/rankinginfo/grpc/RankingGrpcServiceTest.java
+++ b/src/test/java/de/hdawg/rankinginfo/grpc/RankingGrpcServiceTest.java
@@ -29,6 +29,8 @@ import de.hdawg.rankinginfo.repository.RankingRepository;
 @SpringBootTest
 class RankingGrpcServiceTest {
 
+  private static final int GRPC_TEST_PORT = 9095;
+
   @Autowired RankingRepository rankingRepository;
   @Autowired ImportHistoryRepository importHistoryRepository;
   @Autowired CacheManager cacheManager;
@@ -54,7 +56,7 @@ class RankingGrpcServiceTest {
       cache.clear();
     }
 
-    channel = ManagedChannelBuilder.forAddress("localhost", 9095).usePlaintext().build();
+    channel = ManagedChannelBuilder.forAddress("localhost", GRPC_TEST_PORT).usePlaintext().build();
     unauthedStub = RankingServiceGrpc.newBlockingStub(channel);
     var metadata = new Metadata();
     metadata.put(GrpcAuthInterceptor.AUTHORIZATION_KEY, "Bearer test-api-token");
@@ -96,5 +98,17 @@ class RankingGrpcServiceTest {
     assertEquals(2, mueller.getPositionChange());
     var schmidt = response.getItemsList().stream().filter(i -> i.getDtbId() == 10_002_002).findFirst().orElseThrow();
     assertEquals(false, schmidt.hasPositionChange());
+  }
+
+  @Test
+  @DisplayName("defaults to page 1 / per_page 25 when omitted, matching REST behavior")
+  void defaultsPaginationWhenOmitted() {
+    var request = ListListingsRequest.newBuilder().setQuarter(quarter).setAgeGroupSlug("m00").build();
+
+    var response = authedStub.listListings(request);
+
+    assertEquals(2, response.getItemsCount());
+    assertEquals(1, response.getPageInfo().getPage());
+    assertEquals(25, response.getPageInfo().getPerPage());
   }
 }

--- a/src/test/java/de/hdawg/rankinginfo/grpc/RankingGrpcServiceTest.java
+++ b/src/test/java/de/hdawg/rankinginfo/grpc/RankingGrpcServiceTest.java
@@ -1,0 +1,100 @@
+package de.hdawg.rankinginfo.grpc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.MetadataUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.CacheManager;
+
+import de.hdawg.rankinginfo.domain.Ranking;
+import de.hdawg.rankinginfo.grpc.v1.ListListingsRequest;
+import de.hdawg.rankinginfo.grpc.v1.RankingServiceGrpc;
+import de.hdawg.rankinginfo.repository.ImportHistoryRepository;
+import de.hdawg.rankinginfo.repository.RankingRepository;
+
+@SpringBootTest
+class RankingGrpcServiceTest {
+
+  @Autowired RankingRepository rankingRepository;
+  @Autowired ImportHistoryRepository importHistoryRepository;
+  @Autowired CacheManager cacheManager;
+
+  private final String quarter = "2026-04-01";
+  private final String prevQuarter = "2026-01-01";
+
+  private ManagedChannel channel;
+  private RankingServiceGrpc.RankingServiceBlockingStub authedStub;
+  private RankingServiceGrpc.RankingServiceBlockingStub unauthedStub;
+
+  @BeforeEach
+  void setUp() {
+    var q = LocalDate.parse(quarter);
+    var pq = LocalDate.parse(prevQuarter);
+    rankingRepository.saveAll(
+        List.of(
+            ranking(10_001_001, "Mueller", "Hans", "m00", q, 1, "500"),
+            ranking(10_002_002, "Schmidt", "Peter", "m00", q, 2, "490"),
+            ranking(10_001_001, "Mueller", "Hans", "m00", pq, 3, "460")));
+    var cache = cacheManager.getCache("available_dates");
+    if (cache != null) {
+      cache.clear();
+    }
+
+    channel = ManagedChannelBuilder.forAddress("localhost", 9095).usePlaintext().build();
+    unauthedStub = RankingServiceGrpc.newBlockingStub(channel);
+    var metadata = new Metadata();
+    metadata.put(GrpcAuthInterceptor.AUTHORIZATION_KEY, "Bearer test-api-token");
+    authedStub = unauthedStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata));
+  }
+
+  @AfterEach
+  void tearDown() {
+    channel.shutdownNow();
+    rankingRepository.deleteAll();
+    importHistoryRepository.deleteAll();
+  }
+
+  private static Ranking ranking(
+      int dtbId, String lastname, String firstname, String ageGroup, LocalDate date, int position, String score) {
+    return new Ranking(0, dtbId, lastname, firstname, "GER", ageGroup, date, position, score, "TC Test", "WTV", false, false, false);
+  }
+
+  @Test
+  @DisplayName("rejects request without an API token")
+  void rejectsRequestWithoutToken() {
+    var request = ListListingsRequest.newBuilder().setQuarter(quarter).setAgeGroupSlug("m00").setPage(1).setPerPage(25).build();
+
+    var ex = assertThrows(StatusRuntimeException.class, () -> unauthedStub.listListings(request));
+
+    assertEquals(Status.Code.UNAUTHENTICATED, ex.getStatus().getCode());
+  }
+
+  @Test
+  @DisplayName("returns paginated listing with position-change deltas")
+  void returnsPaginatedListingWithPositionChange() {
+    var request = ListListingsRequest.newBuilder().setQuarter(quarter).setAgeGroupSlug("m00").setPage(1).setPerPage(25).build();
+
+    var response = authedStub.listListings(request);
+
+    assertEquals(2, response.getItemsCount());
+    assertEquals(2, response.getPageInfo().getTotalCount());
+    var mueller = response.getItemsList().stream().filter(i -> i.getDtbId() == 10_001_001).findFirst().orElseThrow();
+    assertEquals(2, mueller.getPositionChange());
+    var schmidt = response.getItemsList().stream().filter(i -> i.getDtbId() == 10_002_002).findFirst().orElseThrow();
+    assertEquals(false, schmidt.hasPositionChange());
+  }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -16,6 +16,12 @@ api:
   tokens:
     - test-api-token
 
+grpc:
+  server:
+    port: 9095
+    reflection-service-enabled: true
+    health-service-enabled: true
+
 import:
   folder: /tmp/ranking-import-test
   schedule: "-"


### PR DESCRIPTION
## Summary

Adds a gRPC API layer alongside the existing REST API (`/api/v1/**`), exposing the same functionality through three gRPC services secured by the same bearer-token API key and rate limit:

- `RankingService.ListListings` — mirrors `ListingsApiController`
- `PlayerService.SearchPlayers` / `GetPlayer` — mirrors `PlayersApiController`
- `ClubService.SearchClubs` / `GetClub` — mirrors `ClubsApiController`

Key points:
- gRPC server runs on port 9090 (9095 in tests) via `net.devh:grpc-server-spring-boot-starter`, alongside the existing Tomcat/REST server on 8080.
- Auth (`ApiTokenValidator`) and rate limiting (`RequestRateLimiter`) are extracted out of the existing REST filters (`BearerTokenFilter`, `RateLimitFilter`) into shared components, so REST and gRPC share one token store and one 1000-req/h budget per token/IP.
- Errors are mapped via `GrpcAdvice`/`GrpcExceptionHandler` (`GrpcExceptionAdvice`), mirroring `GlobalApiExceptionHandler`.
- Server reflection and the standard gRPC health-check service are enabled and exempt from auth/rate-limiting, matching REST's unauthenticated `/actuator/health`.
- A REST/gRPC parity test proves both surfaces return identical data for the listings endpoint.

## Test plan

- [x] `./mvnw test` — 258/258 passing
- [x] `./mvnw spotless:check pmd:check` — clean
- [x] Full whole-branch code review completed (2 Important + 5 Minor findings, all fixed and re-verified)
- [x] Manual smoke test with `grpcurl`/reflection against a running instance (not done in this session — recommend before merging to a shared environment)