### PR TITLE
Harden the public API: pagination, rate-limit memory, club search

### DIFF
--- a/src/main/java/de/hdawg/rankinginfo/api/security/RequestRateLimiter.java
+++ b/src/main/java/de/hdawg/rankinginfo/api/security/RequestRateLimiter.java
@@ -1,6 +1,10 @@
 package de.hdawg.rankinginfo.api.security;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
+import java.util.HexFormat;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
@@ -8,21 +12,68 @@ import io.github.bucket4j.Bandwidth;
 import io.github.bucket4j.Bucket;
 import org.springframework.stereotype.Component;
 
+import de.hdawg.rankinginfo.config.ApiProperties;
+
+/// Shared token-bucket rate limiter for the REST and gRPC APIs: 1000 requests per hour per key,
+/// where the key is the caller's bearer token or, failing that, its remote address.
+///
+/// Both protocols rate-limit *before* authenticating, so unauthenticated callers can insert
+/// entries here. The cache is therefore bounded on two axes:
+/// - **Entry count** — `maximumSize` caps how many buckets exist, so rotating keys cannot grow the
+///   cache without limit. Eviction means a caller whose bucket was evicted starts over with a full
+///   allowance, which is the accepted trade-off for a fixed memory ceiling.
+/// - **Entry size** — keys are hashed before use, so an oversized `Authorization` header cannot be
+///   retained verbatim.
 @Component
 public class RequestRateLimiter {
 
-  private final Cache<String, Bucket> buckets =
-      Caffeine.newBuilder().expireAfterAccess(Duration.ofHours(2)).build();
+  private static final Duration BUCKET_TTL = Duration.ofHours(2);
+  private static final int CAPACITY_PER_HOUR = 1000;
 
+  private final Cache<String, Bucket> buckets;
+
+  public RequestRateLimiter(ApiProperties apiProperties) {
+    this.buckets =
+        Caffeine.newBuilder()
+            .maximumSize(apiProperties.rateLimit().maxBuckets())
+            .expireAfterAccess(BUCKET_TTL)
+            .build();
+  }
+
+  /// Consumes a single token from the bucket belonging to `key`.
+  ///
+  /// @param key the caller identity: the raw `Authorization` header value, or the remote address
+  ///     when no such header is present. Untrusted and unbounded in length; hashed internally
+  /// @return `true` if the request is within the limit, `false` if the bucket is exhausted
   public boolean tryConsume(String key) {
-    var bucket = buckets.get(key, k -> createBucket());
+    var bucket = buckets.get(hash(key), k -> createBucket());
     return bucket.tryConsume(1);
+  }
+
+  /// Number of buckets currently held, for monitoring how close the limiter runs to its ceiling.
+  ///
+  /// @return the tracked bucket count after pending evictions have been applied
+  public long trackedBuckets() {
+    buckets.cleanUp();
+    return buckets.estimatedSize();
+  }
+
+  private static String hash(String key) {
+    try {
+      var digest = MessageDigest.getInstance("SHA-256");
+      return HexFormat.of().formatHex(digest.digest(key.getBytes(StandardCharsets.UTF_8)));
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("SHA-256 not available", e);
+    }
   }
 
   private static Bucket createBucket() {
     return Bucket.builder()
         .addLimit(
-            Bandwidth.builder().capacity(1000).refillGreedy(1000, Duration.ofHours(1)).build())
+            Bandwidth.builder()
+                .capacity(CAPACITY_PER_HOUR)
+                .refillGreedy(CAPACITY_PER_HOUR, Duration.ofHours(1))
+                .build())
         .build();
   }
 }

--- a/src/main/java/de/hdawg/rankinginfo/api/v1/ClubsApiController.java
+++ b/src/main/java/de/hdawg/rankinginfo/api/v1/ClubsApiController.java
@@ -51,6 +51,13 @@ public class ClubsApiController {
       return ResponseEntity.badRequest()
           .body(ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, "name parameter required"));
     }
+    if (name.trim().length() < ClubService.MIN_SEARCH_TERM_LENGTH) {
+      return ResponseEntity.badRequest()
+          .body(
+              ProblemDetail.forStatusAndDetail(
+                  HttpStatus.BAD_REQUEST,
+                  "name must be at least " + ClubService.MIN_SEARCH_TERM_LENGTH + " characters"));
+    }
 
     var clubs = clubService.searchClubs(name);
     if (clubs.isEmpty()) {

--- a/src/main/java/de/hdawg/rankinginfo/api/v1/ListingsApiController.java
+++ b/src/main/java/de/hdawg/rankinginfo/api/v1/ListingsApiController.java
@@ -20,6 +20,7 @@ import de.hdawg.rankinginfo.api.v1.dto.ListingRequest;
 import de.hdawg.rankinginfo.api.v1.dto.ListingResponse;
 import de.hdawg.rankinginfo.api.v1.dto.PlayerLink;
 import de.hdawg.rankinginfo.domain.Ranking;
+import de.hdawg.rankinginfo.service.Pagination;
 import de.hdawg.rankinginfo.service.RankingFilter;
 import de.hdawg.rankinginfo.service.RankingService;
 
@@ -27,8 +28,6 @@ import de.hdawg.rankinginfo.service.RankingService;
 @RequestMapping("/api/v1/listings")
 @SecurityRequirement(name = "bearerAuth")
 public class ListingsApiController {
-
-  private static final int MAX_PER_PAGE = 100;
 
   private final RankingService rankingService;
 
@@ -50,7 +49,7 @@ public class ListingsApiController {
       HttpServletRequest request) {
 
     var filter = new RankingFilter(quarter, ageGroupSlug, ageGroupOptions, federation, club, yearEnd);
-    int cappedPerPage = Math.min(perPage, MAX_PER_PAGE);
+    var pagination = Pagination.of(page, perPage);
 
     var maxImportedAt = rankingService.maxImportedAt();
     var etagSource =
@@ -63,15 +62,16 @@ public class ListingsApiController {
                 federation,
                 club,
                 yearEnd,
-                page,
-                cappedPerPage);
+                pagination.page(),
+                pagination.perPage());
     var etag = "\"" + sha256(etagSource) + "\"";
     var ifNoneMatch = request.getHeader("If-None-Match");
     if (etag.equals(ifNoneMatch)) {
       return ResponseEntity.status(304).build();
     }
 
-    var rankings = rankingService.findFilteredRankings(filter, page, cappedPerPage);
+    var rankings =
+        rankingService.findFilteredRankings(filter, pagination.page(), pagination.perPage());
     var dtbIds = rankings.getContent().stream().map(Ranking::dtbId).toList();
     var prevPositions = rankingService.findPreviousPositions(filter, dtbIds);
 
@@ -104,8 +104,8 @@ public class ListingsApiController {
                 federation,
                 club,
                 yearEnd,
-                page,
-                cappedPerPage,
+                pagination.page(),
+                pagination.perPage(),
                 rankings.getTotalElements()),
             data);
 

--- a/src/main/java/de/hdawg/rankinginfo/config/ApiProperties.java
+++ b/src/main/java/de/hdawg/rankinginfo/config/ApiProperties.java
@@ -3,10 +3,48 @@ package de.hdawg.rankinginfo.config;
 import java.util.List;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
+/// Configuration for the public API, bound from the `api.*` properties.
+///
+/// @param tokens accepted bearer tokens; `null` is treated as an empty list
+/// @param rateLimit rate-limiter tuning; `null` falls back to [RateLimit#defaults()]
 @ConfigurationProperties(prefix = "api")
-public record ApiProperties(List<String> tokens) {
-  public ApiProperties {
-    tokens = tokens == null ? List.of() : List.copyOf(tokens);
+public record ApiProperties(List<String> tokens, RateLimit rateLimit) {
+
+  @ConstructorBinding
+  public ApiProperties(List<String> tokens, RateLimit rateLimit) {
+    this.tokens = tokens == null ? List.of() : List.copyOf(tokens);
+    this.rateLimit = rateLimit == null ? RateLimit.defaults() : rateLimit;
+  }
+
+  /// Convenience constructor applying the default rate-limit settings.
+  ///
+  /// @param tokens accepted bearer tokens
+  public ApiProperties(List<String> tokens) {
+    this(tokens, null);
+  }
+
+  /// Tuning for the shared request rate limiter.
+  ///
+  /// @param maxBuckets the maximum number of per-key buckets held in memory at once; values below
+  ///     `1` fall back to [#DEFAULT_MAX_BUCKETS]
+  public record RateLimit(int maxBuckets) {
+
+    /// Bucket ceiling used when `api.rate-limit.max-buckets` is unset or invalid.
+    public static final int DEFAULT_MAX_BUCKETS = 10_000;
+
+    private static final int MIN_MAX_BUCKETS = 1;
+
+    public RateLimit {
+      if (maxBuckets < MIN_MAX_BUCKETS) {
+        maxBuckets = DEFAULT_MAX_BUCKETS;
+      }
+    }
+
+    /// @return rate-limit settings using [#DEFAULT_MAX_BUCKETS]
+    public static RateLimit defaults() {
+      return new RateLimit(DEFAULT_MAX_BUCKETS);
+    }
   }
 }

--- a/src/main/java/de/hdawg/rankinginfo/grpc/RankingGrpcService.java
+++ b/src/main/java/de/hdawg/rankinginfo/grpc/RankingGrpcService.java
@@ -9,13 +9,12 @@ import de.hdawg.rankinginfo.grpc.v1.ListListingsResponse;
 import de.hdawg.rankinginfo.grpc.v1.ListingItem;
 import de.hdawg.rankinginfo.grpc.v1.PageInfo;
 import de.hdawg.rankinginfo.grpc.v1.RankingServiceGrpc;
+import de.hdawg.rankinginfo.service.Pagination;
 import de.hdawg.rankinginfo.service.RankingFilter;
 import de.hdawg.rankinginfo.service.RankingService;
 
 @GrpcService
 public class RankingGrpcService extends RankingServiceGrpc.RankingServiceImplBase {
-
-  private static final int MAX_PER_PAGE = 100;
 
   private final RankingService rankingService;
 
@@ -26,8 +25,7 @@ public class RankingGrpcService extends RankingServiceGrpc.RankingServiceImplBas
   @Override
   public void listListings(
       ListListingsRequest request, StreamObserver<ListListingsResponse> responseObserver) {
-    var page = request.getPage() < 1 ? 1 : request.getPage();
-    var cappedPerPage = request.getPerPage() < 1 ? 25 : Math.min(request.getPerPage(), MAX_PER_PAGE);
+    var pagination = Pagination.of(request.getPage(), request.getPerPage());
     var filter =
         new RankingFilter(
             request.getQuarter(),
@@ -37,7 +35,8 @@ public class RankingGrpcService extends RankingServiceGrpc.RankingServiceImplBas
             request.getClub().isBlank() ? null : request.getClub(),
             request.getYearEnd());
 
-    var rankings = rankingService.findFilteredRankings(filter, page, cappedPerPage);
+    var rankings =
+        rankingService.findFilteredRankings(filter, pagination.page(), pagination.perPage());
     var dtbIds = rankings.getContent().stream().map(Ranking::dtbId).toList();
     var prevPositions = rankingService.findPreviousPositions(filter, dtbIds);
 
@@ -51,8 +50,8 @@ public class RankingGrpcService extends RankingServiceGrpc.RankingServiceImplBas
             .setFederation(request.getFederation())
             .setClub(request.getClub())
             .setYearEnd(request.getYearEnd())
-            .setPage(page)
-            .setPerPage(cappedPerPage)
+            .setPage(pagination.page())
+            .setPerPage(pagination.perPage())
             .build();
 
     var response =
@@ -61,8 +60,8 @@ public class RankingGrpcService extends RankingServiceGrpc.RankingServiceImplBas
             .addAllItems(items)
             .setPageInfo(
                 PageInfo.newBuilder()
-                    .setPage(page)
-                    .setPerPage(cappedPerPage)
+                    .setPage(pagination.page())
+                    .setPerPage(pagination.perPage())
                     .setTotalCount(rankings.getTotalElements())
                     .build())
             .build();

--- a/src/main/java/de/hdawg/rankinginfo/repository/ClubPlayerCount.java
+++ b/src/main/java/de/hdawg/rankinginfo/repository/ClubPlayerCount.java
@@ -1,0 +1,9 @@
+package de.hdawg.rankinginfo.repository;
+
+/// Aggregated player counts for a single club at one ranking date, produced by a `GROUP BY club`
+/// query so that club search never has to load the underlying ranking rows.
+///
+/// @param club the club name exactly as stored
+/// @param youthCount number of youth ranking rows (`age_group = "overall"`)
+/// @param adultCount number of adult ranking rows (`age_group` in `m00`/`w00`)
+public record ClubPlayerCount(String club, long youthCount, long adultCount) {}

--- a/src/main/java/de/hdawg/rankinginfo/repository/RankingEntityRepository.java
+++ b/src/main/java/de/hdawg/rankinginfo/repository/RankingEntityRepository.java
@@ -114,11 +114,24 @@ interface RankingEntityRepository extends ListCrudRepository<RankingEntity, Long
 
   @Query(
       "SELECT * FROM rankings WHERE date = :date AND age_group IN (:ageGroups)"
-          + " AND LOWER(club) LIKE :clubPattern ORDER BY ranking_position ASC")
-  List<RankingEntity> findByDateAgeGroupsAndClub(
+          + " AND LOWER(club) = :club ORDER BY ranking_position ASC")
+  List<RankingEntity> findByDateAgeGroupsAndExactClub(
       @Param("date") LocalDate date,
       @Param("ageGroups") List<String> ageGroups,
-      @Param("clubPattern") String clubPattern);
+      @Param("club") String club);
+
+  // Aggregates in SQL so club search never materializes the matching ranking rows.
+  // SUM(CASE ...) rather than COUNT(*) FILTER (...) to stay portable across PostgreSQL and H2.
+  @Query(
+      "SELECT club,"
+          + " SUM(CASE WHEN age_group = 'overall' THEN 1 ELSE 0 END) AS youth_count,"
+          + " SUM(CASE WHEN age_group IN ('m00', 'w00') THEN 1 ELSE 0 END) AS adult_count"
+          + " FROM rankings"
+          + " WHERE date = :date AND age_group IN ('overall', 'm00', 'w00')"
+          + " AND LOWER(club) LIKE :clubPattern"
+          + " GROUP BY club ORDER BY club ASC")
+  List<ClubPlayerCount> countPlayersByClub(
+      @Param("date") LocalDate date, @Param("clubPattern") String clubPattern);
 
   @Query(
       "SELECT * FROM rankings"

--- a/src/main/java/de/hdawg/rankinginfo/repository/RankingRepository.java
+++ b/src/main/java/de/hdawg/rankinginfo/repository/RankingRepository.java
@@ -200,13 +200,31 @@ public class RankingRepository {
         .toList();
   }
 
-  public List<Ranking> findByDateAndAgeGroupsAndClubContaining(
+  /// Loads the rankings of the club whose name matches `club` exactly, ignoring case.
+  ///
+  /// @param date the ranking date to query
+  /// @param ageGroups the age groups to include
+  /// @param club the full club name; matched case-insensitively, not as a substring
+  /// @return the matching rankings ordered by ranking position
+  public List<Ranking> findByDateAndAgeGroupsAndExactClub(
       LocalDate date, List<String> ageGroups, String club) {
     return jdbc
-        .findByDateAgeGroupsAndClub(date, ageGroups, "%" + club.toLowerCase(Locale.ROOT) + "%")
+        .findByDateAgeGroupsAndExactClub(date, ageGroups, club.toLowerCase(Locale.ROOT))
         .stream()
         .map(RankingEntity::toDomain)
         .toList();
+  }
+
+  /// Counts youth and adult players per club for clubs whose name contains `club`.
+  ///
+  /// Aggregation happens in the database, so a broad search term returns one small row per club
+  /// instead of every matching ranking row.
+  ///
+  /// @param date the ranking date to query
+  /// @param club substring to match against club names, case-insensitively
+  /// @return per-club youth/adult counts, ordered by club name
+  public List<ClubPlayerCount> countPlayersByClubContaining(LocalDate date, String club) {
+    return jdbc.countPlayersByClub(date, "%" + club.toLowerCase(Locale.ROOT) + "%");
   }
 
   public List<Ranking> findAgeGroupRankingsByDateAndDtbIds(LocalDate date, List<Integer> dtbIds) {

--- a/src/main/java/de/hdawg/rankinginfo/service/Pagination.java
+++ b/src/main/java/de/hdawg/rankinginfo/service/Pagination.java
@@ -1,0 +1,42 @@
+package de.hdawg.rankinginfo.service;
+
+/// Normalized pagination parameters shared by the REST and gRPC listing endpoints.
+///
+/// Both protocols accept untrusted `page`/`per_page` values from clients. [#of(int, int)] is the
+/// single place that clamps them into a usable range, so the two APIs cannot drift apart:
+/// - `page` below `1` is clamped to the first page
+/// - `perPage` below `1` falls back to [#DEFAULT_PER_PAGE]
+/// - `perPage` above [#MAX_PER_PAGE] is capped
+///
+/// Instances are always valid, so callers can pass them straight to the repository layer.
+///
+/// @param page the one-based page number, guaranteed to be `>= 1`
+/// @param perPage the page size, guaranteed to be within `1..`[#MAX_PER_PAGE]
+public record Pagination(int page, int perPage) {
+
+  /// Page size used when a client omits `per_page` or supplies a non-positive value.
+  public static final int DEFAULT_PER_PAGE = 25;
+
+  /// Upper bound on the page size a client may request.
+  public static final int MAX_PER_PAGE = 100;
+
+  /// Clamps raw client-supplied pagination values into a valid range.
+  ///
+  /// @param page the requested one-based page number; values below `1` are clamped to `1`
+  /// @param perPage the requested page size; non-positive values fall back to
+  ///     [#DEFAULT_PER_PAGE], values above [#MAX_PER_PAGE] are capped
+  /// @return normalized pagination parameters
+  public static Pagination of(int page, int perPage) {
+    int clampedPage = Math.max(page, 1);
+    int clampedPerPage = perPage < 1 ? DEFAULT_PER_PAGE : Math.min(perPage, MAX_PER_PAGE);
+    return new Pagination(clampedPage, clampedPerPage);
+  }
+
+  /// Zero-based row offset for this page, computed in `long` arithmetic so that deep pages cannot
+  /// overflow into a negative SQL `OFFSET`.
+  ///
+  /// @return the number of rows to skip
+  public long offset() {
+    return (page - 1L) * perPage;
+  }
+}

--- a/src/main/java/de/hdawg/rankinginfo/web/ClubController.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/ClubController.java
@@ -33,7 +33,14 @@ public class ClubController {
     model.addAttribute("searchParams", params);
 
     if (commit != null && club != null && !club.isBlank()) {
-      model.addAttribute("clubs", clubService.searchClubs(club));
+      // Guard here rather than letting ClubService throw: a too-short term is normal typing, not
+      // an error worth redirecting the user away from the search form for.
+      if (club.trim().length() < ClubService.MIN_SEARCH_TERM_LENGTH) {
+        model.addAttribute(
+            "danger", "Bitte mindestens " + ClubService.MIN_SEARCH_TERM_LENGTH + " Zeichen eingeben.");
+      } else {
+        model.addAttribute("clubs", clubService.searchClubs(club));
+      }
     }
     return htmxRequest ? "clubs/results" : "clubs/index";
   }

--- a/src/main/java/de/hdawg/rankinginfo/web/ClubService.java
+++ b/src/main/java/de/hdawg/rankinginfo/web/ClubService.java
@@ -5,7 +5,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Service;
@@ -30,6 +29,13 @@ import de.hdawg.rankinginfo.web.viewmodel.PlayerSummaryRow;
 @Transactional(readOnly = true)
 public class ClubService {
 
+  /// Shortest club-search term accepted. A single character matches almost every club, which
+  /// would turn one request into a scan of the whole quarter.
+  public static final int MIN_SEARCH_TERM_LENGTH = 2;
+
+  private static final String TOO_SHORT_MESSAGE =
+      "Bitte mindestens " + MIN_SEARCH_TERM_LENGTH + " Zeichen eingeben.";
+
   private static final String AGE_GROUP_OVERALL = "overall";
   private static final String AGE_GROUP_M00 = "m00";
   private static final String AGE_GROUP_W00 = "w00";
@@ -48,31 +54,26 @@ public class ClubService {
   /// - the number of youth players (`age_group = "overall"`)
   /// - the number of adult players (`age_group = "m00"` or `"w00"`)
   ///
+  /// Counting happens in the database. A very broad term therefore costs one row per club rather
+  /// than one row per player; `searchTerm` must still be at least [#MIN_SEARCH_TERM_LENGTH]
+  /// characters long so a single character cannot scan the whole quarter.
+  ///
   /// @param searchTerm substring to match against club names
   /// @return matching clubs sorted by name, with youth/adult player counts; empty if no ranking
   ///     data is available yet
+  /// @throws IllegalArgumentException if `searchTerm` is shorter than [#MIN_SEARCH_TERM_LENGTH]
+  ///     characters after trimming
   public List<ClubSummary> searchClubs(String searchTerm) {
+    var term = searchTerm == null ? "" : searchTerm.trim();
+    if (term.length() < MIN_SEARCH_TERM_LENGTH) {
+      throw new IllegalArgumentException(TOO_SHORT_MESSAGE);
+    }
+
     var quarter = rankingRepository.findLatestDate();
     if (quarter == null) return List.of();
 
-    var all = rankingRepository.findByDateAndAgeGroupsAndClubContaining(
-        quarter, List.of(AGE_GROUP_OVERALL, AGE_GROUP_M00, AGE_GROUP_W00), searchTerm);
-    var youthByClub = all.stream()
-        .filter(r -> AGE_GROUP_OVERALL.equals(r.ageGroup()))
-        .collect(Collectors.groupingBy(Ranking::club));
-    var adultByClub = all.stream()
-        .filter(r -> !AGE_GROUP_OVERALL.equals(r.ageGroup()))
-        .collect(Collectors.groupingBy(Ranking::club));
-
-    return Stream.concat(youthByClub.keySet().stream(), adultByClub.keySet().stream())
-        .distinct()
-        .sorted()
-        .map(
-            name ->
-                new ClubSummary(
-                    name,
-                    youthByClub.getOrDefault(name, List.of()).size(),
-                    adultByClub.getOrDefault(name, List.of()).size()))
+    return rankingRepository.countPlayersByClubContaining(quarter, term).stream()
+        .map(c -> new ClubSummary(c.club(), (int) c.youthCount(), (int) c.adultCount()))
         .toList();
   }
 
@@ -94,11 +95,8 @@ public class ClubService {
     var players = new LinkedHashMap<String, List<PlayerSummaryRow>>();
     if (quarter == null) return players;
 
-    var all = rankingRepository.findByDateAndAgeGroupsAndClubContaining(
-        quarter, List.of(AGE_GROUP_OVERALL, AGE_GROUP_M00, AGE_GROUP_W00), clubId)
-        .stream()
-        .filter(r -> r.club().equalsIgnoreCase(clubId))
-        .toList();
+    var all = rankingRepository.findByDateAndAgeGroupsAndExactClub(
+        quarter, List.of(AGE_GROUP_OVERALL, AGE_GROUP_M00, AGE_GROUP_W00), clubId);
 
     for (var entry : ADULT_LABELS.entrySet()) {
       var adults = all.stream().filter(r -> r.ageGroup().equals(entry.getKey())).toList();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,6 +21,10 @@ server:
 
 api:
   tokens: []
+  rate-limit:
+    # Caps how many per-key buckets the rate limiter holds. Callers are rate-limited before they
+    # are authenticated, so this bounds memory against clients rotating their Authorization header.
+    max-buckets: ${RATE_LIMIT_MAX_BUCKETS:10000}
 
 grpc:
   server:

--- a/src/test/java/de/hdawg/rankinginfo/api/ClubsApiControllerTest.java
+++ b/src/test/java/de/hdawg/rankinginfo/api/ClubsApiControllerTest.java
@@ -81,6 +81,15 @@ class ClubsApiControllerTest {
   }
 
   @Test
+  @DisplayName("search returns 400 when name is shorter than the minimum length")
+  void searchReturns400WhenNameTooShort() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/clubs?name=E").header("Authorization", auth))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.detail").value("name must be at least 2 characters"));
+  }
+
+  @Test
   @DisplayName("search returns 404 when no club matches")
   void searchReturns404WhenNoClubMatches() throws Exception {
     mockMvc

--- a/src/test/java/de/hdawg/rankinginfo/api/ListingsApiControllerTest.java
+++ b/src/test/java/de/hdawg/rankinginfo/api/ListingsApiControllerTest.java
@@ -182,6 +182,44 @@ class ListingsApiControllerTest {
   }
 
   @Test
+  @DisplayName("page below one is clamped to the first page")
+  void pageBelowOneIsClampedToFirstPage() throws Exception {
+    for (var page : List.of("0", "-5")) {
+      mockMvc
+          .perform(
+              get("/api/v1/listings/" + quarter + "/m00?page=" + page)
+                  .header("Authorization", auth))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.request.page").value(1))
+          .andExpect(jsonPath("$.data.length()").value(3));
+    }
+  }
+
+  @Test
+  @DisplayName("per_page below one falls back to the default page size")
+  void perPageBelowOneFallsBackToDefault() throws Exception {
+    for (var perPage : List.of("0", "-3")) {
+      mockMvc
+          .perform(
+              get("/api/v1/listings/" + quarter + "/m00?per_page=" + perPage)
+                  .header("Authorization", auth))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.request.per_page").value(25));
+    }
+  }
+
+  @Test
+  @DisplayName("a page beyond the last one returns an empty result rather than failing")
+  void pageBeyondLastReturnsEmptyResult() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/v1/listings/" + quarter + "/m00?page=1000000").header("Authorization", auth))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.length()").value(0))
+        .andExpect(jsonPath("$.request.total_count").value(3));
+  }
+
+  @Test
   @DisplayName("total_count reflects all records regardless of page size")
   void totalCountReflectsAllRecordsRegardlessOfPageSize() throws Exception {
     mockMvc

--- a/src/test/java/de/hdawg/rankinginfo/api/security/RequestRateLimiterTest.java
+++ b/src/test/java/de/hdawg/rankinginfo/api/security/RequestRateLimiterTest.java
@@ -1,17 +1,31 @@
 package de.hdawg.rankinginfo.api.security;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import de.hdawg.rankinginfo.config.ApiProperties;
+
 class RequestRateLimiterTest {
+
+  private static RequestRateLimiter rateLimiter() {
+    return new RequestRateLimiter(new ApiProperties(List.of()));
+  }
+
+  private static RequestRateLimiter rateLimiter(int maxBuckets) {
+    return new RequestRateLimiter(
+        new ApiProperties(List.of(), new ApiProperties.RateLimit(maxBuckets)));
+  }
 
   @Test
   @DisplayName("allows requests within the limit")
   void allowsRequestsWithinLimit() {
-    var rateLimiter = new RequestRateLimiter();
+    var rateLimiter = rateLimiter();
 
     assertTrue(rateLimiter.tryConsume("key-a"));
   }
@@ -19,7 +33,7 @@ class RequestRateLimiterTest {
   @Test
   @DisplayName("rejects requests once the bucket for a key is exhausted")
   void rejectsRequestsOnceBucketExhausted() {
-    var rateLimiter = new RequestRateLimiter();
+    var rateLimiter = rateLimiter();
 
     for (int i = 0; i < 1000; i++) {
       assertTrue(rateLimiter.tryConsume("key-b"), "expected request " + i + " to be allowed");
@@ -31,7 +45,7 @@ class RequestRateLimiterTest {
   @Test
   @DisplayName("tracks separate buckets per key")
   void tracksSeparateBucketsPerKey() {
-    var rateLimiter = new RequestRateLimiter();
+    var rateLimiter = rateLimiter();
 
     for (int i = 0; i < 1000; i++) {
       rateLimiter.tryConsume("exhausted-key");
@@ -39,5 +53,44 @@ class RequestRateLimiterTest {
     assertFalse(rateLimiter.tryConsume("exhausted-key"));
 
     assertTrue(rateLimiter.tryConsume("fresh-key"));
+  }
+
+  @Test
+  @DisplayName("never tracks more buckets than the configured maximum")
+  void neverTracksMoreBucketsThanConfiguredMaximum() {
+    var rateLimiter = rateLimiter(10);
+
+    for (int i = 0; i < 5000; i++) {
+      rateLimiter.tryConsume("rotating-key-" + i);
+    }
+
+    assertThat(rateLimiter.trackedBuckets()).isLessThanOrEqualTo(10);
+  }
+
+  @Test
+  @DisplayName("falls back to the default bucket limit when none is configured")
+  void fallsBackToDefaultBucketLimit() {
+    var rateLimiter = rateLimiter();
+
+    for (int i = 0; i < 12_000; i++) {
+      rateLimiter.tryConsume("rotating-key-" + i);
+    }
+
+    assertThat(rateLimiter.trackedBuckets())
+        .isLessThanOrEqualTo(ApiProperties.RateLimit.DEFAULT_MAX_BUCKETS);
+  }
+
+  @Test
+  @DisplayName("keys that share a long prefix are still limited independently")
+  void longKeysSharingPrefixAreLimitedIndependently() {
+    var rateLimiter = rateLimiter();
+    var prefix = "Bearer " + "x".repeat(8000);
+
+    for (int i = 0; i < 1000; i++) {
+      rateLimiter.tryConsume(prefix + "a");
+    }
+
+    assertFalse(rateLimiter.tryConsume(prefix + "a"));
+    assertTrue(rateLimiter.tryConsume(prefix + "b"));
   }
 }

--- a/src/test/java/de/hdawg/rankinginfo/config/ApiPropertiesTest.java
+++ b/src/test/java/de/hdawg/rankinginfo/config/ApiPropertiesTest.java
@@ -1,0 +1,59 @@
+package de.hdawg.rankinginfo.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
+
+class ApiPropertiesTest {
+
+  private static ApiProperties bind(Map<String, Object> properties) {
+    return new Binder(new MapConfigurationPropertySource(properties))
+        .bind("api", ApiProperties.class)
+        .orElseThrow(() -> new AssertionError("api properties did not bind"));
+  }
+
+  @Test
+  @DisplayName("binds tokens and the rate-limit bucket ceiling from configuration")
+  void bindsTokensAndRateLimit() {
+    var properties =
+        bind(
+            Map.of(
+                "api.tokens[0]", "token-a",
+                "api.rate-limit.max-buckets", "512"));
+
+    assertThat(properties.tokens()).containsExactly("token-a");
+    assertThat(properties.rateLimit().maxBuckets()).isEqualTo(512);
+  }
+
+  @Test
+  @DisplayName("applies the default bucket ceiling when rate-limit config is absent")
+  void appliesDefaultBucketCeilingWhenAbsent() {
+    var properties = bind(Map.of("api.tokens[0]", "token-a"));
+
+    assertThat(properties.rateLimit().maxBuckets())
+        .isEqualTo(ApiProperties.RateLimit.DEFAULT_MAX_BUCKETS);
+  }
+
+  @Test
+  @DisplayName("rejects a non-positive bucket ceiling in favour of the default")
+  void rejectsNonPositiveBucketCeiling() {
+    var properties = bind(Map.of("api.rate-limit.max-buckets", "0"));
+
+    assertThat(properties.rateLimit().maxBuckets())
+        .isEqualTo(ApiProperties.RateLimit.DEFAULT_MAX_BUCKETS);
+  }
+
+  @Test
+  @DisplayName("treats missing tokens as an empty list")
+  void treatsMissingTokensAsEmptyList() {
+    var properties = bind(Map.of("api.rate-limit.max-buckets", "512"));
+
+    assertThat(properties.tokens()).isEqualTo(List.of());
+  }
+}

--- a/src/test/java/de/hdawg/rankinginfo/grpc/GrpcRateLimitInterceptorTest.java
+++ b/src/test/java/de/hdawg/rankinginfo/grpc/GrpcRateLimitInterceptorTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.net.InetSocketAddress;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.grpc.Attributes;
@@ -18,10 +19,12 @@ import io.grpc.ServerCallHandler;
 import org.junit.jupiter.api.Test;
 
 import de.hdawg.rankinginfo.api.security.RequestRateLimiter;
+import de.hdawg.rankinginfo.config.ApiProperties;
 
 class GrpcRateLimitInterceptorTest {
 
-  private final RequestRateLimiter rateLimiter = new RequestRateLimiter();
+  private final RequestRateLimiter rateLimiter =
+      new RequestRateLimiter(new ApiProperties(List.of()));
   private final GrpcRateLimitInterceptor interceptor = new GrpcRateLimitInterceptor(rateLimiter);
 
   private ServerCall<Object, Object> mockCall() {

--- a/src/test/java/de/hdawg/rankinginfo/service/PaginationTest.java
+++ b/src/test/java/de/hdawg/rankinginfo/service/PaginationTest.java
@@ -1,0 +1,55 @@
+package de.hdawg.rankinginfo.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PaginationTest {
+
+  @Test
+  @DisplayName("keeps valid page and perPage unchanged")
+  void keepsValidValues() {
+    var pagination = Pagination.of(3, 50);
+
+    assertThat(pagination.page()).isEqualTo(3);
+    assertThat(pagination.perPage()).isEqualTo(50);
+  }
+
+  @Test
+  @DisplayName("clamps page below one to the first page")
+  void clampsPageBelowOne() {
+    assertThat(Pagination.of(0, 25).page()).isEqualTo(1);
+    assertThat(Pagination.of(-5, 25).page()).isEqualTo(1);
+    assertThat(Pagination.of(Integer.MIN_VALUE, 25).page()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("falls back to the default page size when perPage is below one")
+  void fallsBackToDefaultPerPage() {
+    assertThat(Pagination.of(1, 0).perPage()).isEqualTo(25);
+    assertThat(Pagination.of(1, -3).perPage()).isEqualTo(25);
+  }
+
+  @Test
+  @DisplayName("caps perPage at the maximum page size")
+  void capsPerPage() {
+    assertThat(Pagination.of(1, 9999).perPage()).isEqualTo(100);
+    assertThat(Pagination.of(1, 100).perPage()).isEqualTo(100);
+  }
+
+  @Test
+  @DisplayName("offset is zero-based and derived from the clamped values")
+  void computesOffset() {
+    assertThat(Pagination.of(1, 25).offset()).isZero();
+    assertThat(Pagination.of(3, 25).offset()).isEqualTo(50);
+    assertThat(Pagination.of(0, 25).offset()).isZero();
+  }
+
+  @Test
+  @DisplayName("offset does not overflow for very deep pages")
+  void offsetDoesNotOverflow() {
+    assertThat(Pagination.of(Integer.MAX_VALUE, 100).offset())
+        .isEqualTo((Integer.MAX_VALUE - 1L) * 100L);
+  }
+}

--- a/src/test/java/de/hdawg/rankinginfo/web/ClubControllerTest.java
+++ b/src/test/java/de/hdawg/rankinginfo/web/ClubControllerTest.java
@@ -1,6 +1,7 @@
 package de.hdawg.rankinginfo.web;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
@@ -29,6 +30,17 @@ class ClubControllerTest extends WebControllerTestBase {
     mockMvc
         .perform(get("/clubs").param("club", "XYZNOTEXIST").param("commit", "1"))
         .andExpect(status().isOk());
+  }
+
+  @Test
+  @DisplayName("GET clubs with a too-short search term shows a hint instead of searching")
+  void getClubsWithTooShortTermShowsHint() throws Exception {
+    mockMvc
+        .perform(get("/clubs").param("club", "T").param("commit", "1"))
+        .andExpect(status().isOk())
+        .andExpect(view().name("clubs/index"))
+        .andExpect(model().attributeDoesNotExist("clubs"))
+        .andExpect(model().attributeExists("danger"));
   }
 
   @Test

--- a/src/test/java/de/hdawg/rankinginfo/web/ClubServiceTest.java
+++ b/src/test/java/de/hdawg/rankinginfo/web/ClubServiceTest.java
@@ -2,6 +2,7 @@ package de.hdawg.rankinginfo.web;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.DisplayName;
@@ -45,6 +46,48 @@ class ClubServiceTest extends WebControllerTestBase {
   @DisplayName("getClubDetail for unknown club returns empty map")
   void getClubDetailUnknownClub() {
     var detail = clubService.getClubDetail("XYZNOTEXIST");
+    assertTrue(detail.isEmpty());
+  }
+
+  @Test
+  @DisplayName("searchClubs counts youth and adult players per club")
+  void searchClubsCountsPlayersPerClub() {
+    var results = clubService.searchClubs("TC");
+
+    assertEquals(2, results.size());
+
+    var baden = results.get(0);
+    assertEquals("TC Baden", baden.name());
+    assertEquals(1, baden.youthCount());
+    assertEquals(2, baden.adultCount());
+
+    var other = results.get(1);
+    assertEquals("TC Other", other.name());
+    assertEquals(0, other.youthCount());
+    assertEquals(1, other.adultCount());
+  }
+
+  @Test
+  @DisplayName("searchClubs rejects search terms shorter than the minimum length")
+  void searchClubsRejectsTooShortTerm() {
+    assertThrows(IllegalArgumentException.class, () -> clubService.searchClubs("T"));
+    assertThrows(IllegalArgumentException.class, () -> clubService.searchClubs(" "));
+    assertThrows(IllegalArgumentException.class, () -> clubService.searchClubs(""));
+  }
+
+  @Test
+  @DisplayName("getClubDetail matches the club name exactly, ignoring case")
+  void getClubDetailMatchesExactlyIgnoringCase() {
+    var detail = clubService.getClubDetail("tc baden");
+
+    assertFalse(detail.isEmpty());
+  }
+
+  @Test
+  @DisplayName("getClubDetail does not match clubs that merely contain the given name")
+  void getClubDetailDoesNotMatchOnSubstring() {
+    var detail = clubService.getClubDetail("TC");
+
     assertTrue(detail.isEmpty());
   }
 


### PR DESCRIPTION
Fixes three issues found while reviewing the API surface. Each is a separate commit and can be reviewed independently.

## 1. Invalid REST pagination returned 500

`page=0`, `page=-5` and `per_page=-3` reached the database unnormalized and produced a negative SQL `OFFSET`/`LIMIT`, returning 500. `per_page=0` returned 400 leaking an internal Spring Data message. The gRPC endpoint already clamped these values, so the two protocols disagreed on identical input.

Measured before the fix:

| Input | Before | After |
|---|---|---|
| `page=0` | 500 | 200, page 1 |
| `page=-5` | 500 | 200, page 1 |
| `per_page=0` | 400 (leaked message) | 200, per_page 25 |
| `per_page=-3` | 500 | 200, per_page 25 |
| `page=1000000` | 200 | 200 (unchanged) |

The clamping rules now live in a `Pagination` value object used by both API edges, so REST and gRPC cannot drift apart. `Pagination#offset` uses `long` arithmetic so deep pages cannot overflow into a negative offset.

Normalization sits at the API boundary rather than in `RankingService` on purpose: the web `ListingController` deliberately requests 1000 rows per page and must not be subject to the public API's 100-row cap.

## 2. Rate-limiter cache could grow without bound

`RequestRateLimiter` cached one bucket per key with a two-hour expiry and no size limit. Both the REST filter and the gRPC interceptor run *before* authentication, so no valid token was needed to insert entries, and each rotated key got a fresh 1000-request allowance instead of being throttled. The key was the raw `Authorization` header, so entry size was attacker-controlled up to the maximum header size as well.

Bounded on both axes:
- `maximumSize`, configurable via `api.rate-limit.max-buckets` (env `RATE_LIMIT_MAX_BUCKETS`), default 10000
- SHA-256 hashing of the key, so entry size is constant

Eviction means a caller whose bucket is dropped starts over with a full allowance — the accepted trade-off for a fixed memory ceiling. `trackedBuckets()` is exposed so the limiter's distance from its ceiling can be monitored.

`ApiProperties` gains a nested `RateLimit` record. The canonical constructor needs `@ConstructorBinding` because the convenience constructor would otherwise make binding ambiguous; `ApiPropertiesTest` covers this, and all four cases fail if the annotation is removed.

## 3. Club search materialized every matching ranking row

`ClubService.searchClubs` fetched every ranking row for the latest quarter whose club name matched, then grouped them in memory only to derive two counts per club. A one-character term matches almost every club, so one request pulled the whole quarter into the heap.

This was reachable not only from the authenticated REST endpoint but also from `GET /clubs` on the web UI, which is neither authenticated nor rate limited — `RateLimitFilter` only covers `/api/v1`.

- `searchClubs` now uses a `GROUP BY club` query returning one small `ClubPlayerCount` row per club
- search terms must be at least 2 characters: 400 on the API, an inline hint on the web form (the user stays on the search form rather than being redirected)
- `getClubDetail` queries the exact club name in SQL instead of querying by substring and discarding non-matching rows in memory; behavior is unchanged

The grouped query uses `SUM(CASE ...)` rather than `COUNT(*) FILTER (...)` to stay portable across PostgreSQL and the H2 database used in tests.

## Verification

`./mvnw verify` passes: 280 tests (up from 258), SpotBugs, Spotless and PMD clean.

Two notes on test provenance, since not everything was strictly test-first:
- The four `ApiPropertiesTest` cases were written after the implementation and passed immediately. They were confirmed meaningful by removing `@ConstructorBinding` and watching all four fail.
- Three of the new `ClubServiceTest` cases (exact counts, case-insensitive detail lookup, no substring match) also passed before the change. The exact-lookup half of issue 3 is a pure refactor with no behavior change; those tests constrain it rather than drive it.

## Not included

Four further findings from the same review are deliberately out of scope: unconditional `COUNT(*)` plus uncapped page depth on listing queries, unbounded collections during import, the listing index being unable to serve the requested sort order after a DTB-ID range condition, and the absence of production metrics.